### PR TITLE
Add Facebook React development settings mode enabled KB

### DIFF
--- a/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/description.md
+++ b/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/description.md
@@ -1,0 +1,3 @@
+The application is compiled with `com.facebook.react.devsupport.DevSettingsActivity` enabled. The Activity display 
+developers settings, It's added to the debug manifest of the app.
+

--- a/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/description.md
+++ b/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/description.md
@@ -1,3 +1,2 @@
-The application is compiled with `com.facebook.react.devsupport.DevSettingsActivity` enabled. The Activity display 
-developers settings, It's added to the debug manifest of the app.
+The application exposes the `com.facebook.react.devsupport.DevSettingsActivity` activity. The  `DevSettingsActivity` Activity exposes developer settings and should not pas exposed in release versions of the application.
 

--- a/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
@@ -1,6 +1,6 @@
 {
   "risk_rating": "low",
-  "short_description": "Application is compiled with the developer options menu enabled.",
+  "short_description": "Application is compiled with `DevSettingsActivity` developer activity exposed.",
   "references": {
     "Facebook Sdk Debug Logs": "https://www.appsloveworld.com/react-native/100/11/react-native-whats-com-facebook-react-devsupport-devsettingsactivity"
   },

--- a/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
@@ -10,8 +10,12 @@
   "security_issue": true,
   "categories": {
     "OWASP_MASVS_L1": [
+      "MSTG-ARCH-1",
+      "MSTG-CODE-4"
     ],
     "OWASP_MASVS_L2": [
+      "MSTG-ARCH-1",
+      "MSTG-CODE-4"
     ]
   }
 }

--- a/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
@@ -1,0 +1,17 @@
+{
+  "risk_rating": "low",
+  "short_description": "Application is compiled with the developer options menu enabled.",
+  "references": {
+    "Facebook Sdk Debug Logs": "https://www.appsloveworld.com/react-native/100/11/react-native-whats-com-facebook-react-devsupport-devsettingsactivity"
+  },
+  "title": "Facebook React development settings mode enabled",
+  "cvss_v3_vector": "",
+  "privacy_issue": true,
+  "security_issue": true,
+  "categories": {
+    "OWASP_MASVS_L1": [
+    ],
+    "OWASP_MASVS_L2": [
+    ]
+  }
+}

--- a/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
@@ -4,7 +4,7 @@
   "references": {
     "Facebook Sdk Debug Logs": "https://www.appsloveworld.com/react-native/100/11/react-native-whats-com-facebook-react-devsupport-devsettingsactivity"
   },
-  "title": "Facebook React development settings mode enabled",
+  "title": "Facebook React development settings exposed",
   "cvss_v3_vector": "",
   "privacy_issue": true,
   "security_issue": true,

--- a/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/meta.json
@@ -2,7 +2,7 @@
   "risk_rating": "low",
   "short_description": "Application is compiled with `DevSettingsActivity` developer activity exposed.",
   "references": {
-    "Facebook Sdk Debug Logs": "https://www.appsloveworld.com/react-native/100/11/react-native-whats-com-facebook-react-devsupport-devsettingsactivity"
+    "Facebook SDK Debug Logs": "https://www.appsloveworld.com/react-native/100/11/react-native-whats-com-facebook-react-devsupport-devsettingsactivity"
   },
   "title": "Facebook React development settings exposed",
   "cvss_v3_vector": "",

--- a/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/recommendation.md
+++ b/MOBILE_CLIENT/ANDROID/_LOW/APK__FACEBOOK_REACT_DEV_SETTINGS_ENABLED/recommendation.md
@@ -1,0 +1,6 @@
+Disable `com.facebook.react.devsupport.DevSettingsActivity` in `AndroidManifest.xml` before deploying your app to the public.
+
+```xml
+<activity android:name="com.facebook.react.devsupport.DevSettingsActivity"
+      android:exported="false"/>
+```


### PR DESCRIPTION
The application is compiled with `com.facebook.react.devsupport.DevSettingsActivity` enabled. The Activity display 
developers settings, It's added to the debug manifest of the app.