### PR TITLE
Add alias overloading

### DIFF
--- a/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_ALIAS_OVERLOADING/description.md
+++ b/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_ALIAS_OVERLOADING/description.md
@@ -1,0 +1,21 @@
+Alias Overloading in GraphQL occurs when an attacker uses a large number of aliases in a query to overwhelm the server's processing capabilities.
+
+Aliases in GraphQL allow a client to request the same field multiple times with different names. However, excessive use of aliases in a single query can lead to Denial of Service (DoS) attacks by exhausting the server’s resources. This attack can degrade performance or cause complete service outages.
+Example:
+
+```
+query oxo {
+  alias1: __typename
+  alias2: __typename
+  alias3: __typename
+  alias4: __typename
+  alias5: __typename
+  ...
+}
+```
+
+Security Impact of Alias Overloading:
+
+- **Denial of Service**: By sending a query with a large number of aliases, attackers can cause the server to use excessive resources to process and respond, which could slow down or crash the service.
+- **Resource Exhaustion**: Servers may struggle to handle the computational load of processing numerous aliases, potentially leading to memory exhaustion, CPU spikes, or degraded performance.
+- **System Unavailability**: If an Alias Overloading attack goes unchecked, it can render the GraphQL API unavailable, disrupting service for all users.

--- a/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_ALIAS_OVERLOADING/meta.json
+++ b/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_ALIAS_OVERLOADING/meta.json
@@ -1,0 +1,37 @@
+{
+  "risk_rating": "medium",
+  "title": "Alias Overloading in GraphQL API",
+  "short_description": "Exploiting a GraphQL server by overloading queries with excessive aliases, potentially leading to Denial of Service attacks.",
+  "references": {
+    "Checkmarx": "https://checkmarx.com/blog/alias-and-directive-overloading-in-graphql/",
+    "Beagle Security": "https://beaglesecurity.com/blog/article/graphql-attacks-vulnerabilities.html",
+    "Sylhare": "https://sylhare.github.io/2024/04/19/Graphql-vulnerabilities.html"
+  },
+  "privacy_issue": false,
+  "security_issue": true,
+  "categories": {
+    "CWE_TOP_25": [
+      "CWE_400"
+    ],
+    "PCI_STANDARDS": [
+      "REQ_6_2",
+      "REQ_6_4",
+      "REQ_11_3"
+    ],
+    "OWASP_MASVS_L2": [
+      "MSTG_PLATFORM_2"
+    ],
+    "OWASP_ASVS_L3": [
+      "V13_4_1"
+    ],
+    "SOC2_CONTROLS": [
+      "CC_2_1",
+      "CC_4_1",
+      "CC_7_1",
+      "CC_7_2",
+      "CC_7_4",
+      "CC_7_5",
+      "CC_9_1"
+    ]
+  }
+}

--- a/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_ALIAS_OVERLOADING/recommendation.md
+++ b/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_ALIAS_OVERLOADING/recommendation.md
@@ -1,6 +1,6 @@
-To mitigate the risk of Directive Overloading attacks, you can take the following steps:
+To mitigate the risk of Alias Overloading attacks, you can take the following steps:
 
-- **Implement timouts**: Enforce query timeouts to terminate queries that take too long to resolve. By setting a maximum execution time, you can automatically terminate queries that abuse aliases and consume excessive server resources, preventing Denial of Service (DoS) attacks.
+- **Implement timeouts**: Enforce query timeouts to terminate queries that take too long to resolve. By setting a maximum execution time, you can automatically terminate queries that abuse aliases and consume excessive server resources, preventing Denial of Service (DoS) attacks.
 
 - **Limit Aliases**: Configure server-side limits on the number of aliases allowed in a single GraphQL query. You can configure tools like GraphQL Armor to limit aliases and prevent overloading.
 

--- a/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_ALIAS_OVERLOADING/recommendation.md
+++ b/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_ALIAS_OVERLOADING/recommendation.md
@@ -1,0 +1,56 @@
+To mitigate the risk of Directive Overloading attacks, you can take the following steps:
+
+- **Implement timouts**: Enforce query timeouts to terminate queries that take too long to resolve. By setting a maximum execution time, you can automatically terminate queries that abuse aliases and consume excessive server resources, preventing Denial of Service (DoS) attacks.
+
+- **Limit Aliases**: Configure server-side limits on the number of aliases allowed in a single GraphQL query. You can configure tools like GraphQL Armor to limit aliases and prevent overloading.
+
+=== "JavaScript"
+  ```javascript
+    // Configuring for GraphQL Armor
+    GraphQLArmorConfig({
+      maxAliases: {
+        // Enable or disable the plugin | default: true
+        enabled: true,
+        
+        // Set the maximum number of aliases allowed per query | default: 50
+        n: 50,
+    
+        // Callbacks to execute when a query is accepted
+        onAccept: [],
+    
+        // Callbacks to execute when a query is rejected
+        onReject: [],
+    
+        // Propagate rejection details to the client | default: true
+        propagateOnRejection: true,
+      }
+    })
+  ```
+
+
+=== "Python"
+  ```python
+    import graphql
+    from graphql.language import ast
+    from graphql.language import parser
+    from settings import api
+    
+    def validate_aliases(query: str) -> None:
+        """
+        This validation prevents the execution of queries containing an excessive
+        number of aliases to prevent server overload.
+        """
+    
+        class AliasesParser(parser.Parser):
+            def parse_aliases(self) -> list[ast.FieldNode]:
+                aliases = 0
+                while self.peek(graphql.TokenKind.NAME):
+                    aliases += 1
+                    if aliases > api.API_MAX_ALIASES:
+                        raise graphql.GraphQLError("Exception - Max aliases exceeded")
+                    self.parse_field()
+                return []
+    
+        ast_parser = AliasesParser(query)
+        ast_parser.parse_document()
+  ```


### PR DESCRIPTION
This PR adds a new Knowledge Base entry titled "Alias Overloading in GraphQL" to the repository. The entry addresses the vulnerability of Alias Overloading in GraphQL and provides comprehensive information on its risks, examples of exploitation, and effective mitigation strategies. This includes how attackers can overload GraphQL queries with excessive aliases to exhaust server resources, potentially leading to Denial of Service (DoS) attacks, and steps to mitigate these risks effectively.