### PR TITLE
KB entries for Graphql analyzer: debug/tracing enabled

### DIFF
--- a/WEB_SERVICE/WEB/_LOW/GRAPHQL_TRACING/description.md
+++ b/WEB_SERVICE/WEB/_LOW/GRAPHQL_TRACING/description.md
@@ -1,0 +1,47 @@
+GraphQL Tracing is a feature that, when enabled, provides detailed timing information about the execution of a GraphQL query. While useful for debugging and performance optimization, it can potentially leak sensitive information about the server's internal workings when left enabled in a production environment.
+
+When tracing is enabled, the GraphQL server includes an `extensions` field in the response, containing a `tracing` object. This object includes detailed information about the execution of each resolver in the query, including start times, end times, and durations.
+
+Example of a response with tracing enabled:
+
+```json
+{
+  "data": {
+    "field1": "value1",
+    "field2": "value2"
+  },
+  "extensions": {
+    "tracing": {
+      "version": 1,
+      "startTime": "2023-09-17T10:00:00.000Z",
+      "endTime": "2023-09-17T10:00:00.050Z",
+      "duration": 50000000,
+      "execution": {
+        "resolvers": [
+          {
+            "path": ["field1"],
+            "parentType": "Query",
+            "fieldName": "field1",
+            "returnType": "String",
+            "startOffset": 1000000,
+            "duration": 2000000
+          },
+          {
+            "path": ["field2"],
+            "parentType": "Query",
+            "fieldName": "field2",
+            "returnType": "String",
+            "startOffset": 3000000,
+            "duration": 1000000
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Security Impact of GraphQL Tracing:
+- **Information Disclosure**: Tracing data can reveal internal details about the GraphQL server's structure and performance, which could be leveraged by attackers to plan more targeted attacks.
+- **Performance Overhead**: Enabling tracing in production can introduce unnecessary performance overhead, potentially impacting the server's ability to handle high loads.
+- **Data Privacy Concerns**: In some cases, tracing data might include sensitive information that shouldn't be exposed to clients.

--- a/WEB_SERVICE/WEB/_LOW/GRAPHQL_TRACING/meta.json
+++ b/WEB_SERVICE/WEB/_LOW/GRAPHQL_TRACING/meta.json
@@ -1,0 +1,28 @@
+{
+  "risk_rating": "low",
+  "title": "GraphQL Tracing Enabled",
+  "short_description": "If GraphQL tracing is enabled, it may leak sensitive information about query execution.",
+  "references": {
+    "GraphQL": "https://graphql-ruby.org/queries/tracing",
+    "Apollo GraphQL": "https://www.apollographql.com/docs/router/configuration/telemetry/exporters/tracing/overview/"
+  },
+  "privacy_issue": true,
+  "security_issue": true,
+  "categories": {
+    "PCI_STANDARDS": [
+      "REQ_6_5",
+      "REQ_11_3"
+    ],
+    "OWASP_MASVS_L2": [
+      "MSTG_ARCH_9"
+    ],
+    "OWASP_ASVS_L3": [
+      "V1_4_4"
+    ],
+    "SOC2_CONTROLS": [
+      "CC_6_1",
+      "CC_6_7",
+      "CC_7_1"
+    ]
+  }
+}

--- a/WEB_SERVICE/WEB/_LOW/GRAPHQL_TRACING/recommendation.md
+++ b/WEB_SERVICE/WEB/_LOW/GRAPHQL_TRACING/recommendation.md
@@ -1,0 +1,40 @@
+To mitigate the risks associated with GraphQL Tracing, consider the following recommendations:
+
+1. **Disable Tracing in Production**: Ensure that GraphQL tracing is disabled in production environments. Tracing should only be enabled temporarily for debugging purposes and in controlled environments.
+
+2. **Implement Access Controls**: If tracing must be enabled in production for certain scenarios, implement strict access controls to ensure that only authorized personnel can access the tracing data.
+
+3. **Sanitize Tracing Data**: If tracing data must be exposed, implement sanitization mechanisms to remove any potentially sensitive information before sending it to clients.
+
+4. **Use Application Performance Monitoring (APM) Tools**: Instead of relying on GraphQL tracing for performance monitoring in production, consider using dedicated APM tools that provide more secure and comprehensive monitoring capabilities.
+
+Example of disabling tracing in Apollo Server:
+
+=== "javascript"
+
+```javascript
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  tracing: false, // Disable tracing
+});
+```
+
+=== "Python"
+
+```python
+from graphene import Schema
+from graphql import GraphQLBackend
+
+class CustomBackend(GraphQLBackend):
+    def __init__(self):
+        super().__init__(traceback_enabled=False)
+
+schema = Schema(query=Query, mutation=Mutation)
+result = schema.execute(
+    query,
+    backend=CustomBackend()
+)
+```
+
+For other GraphQL server implementations, consult the specific documentation on how to disable tracing or control its behavior in different environments.

--- a/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_DEBUG_MODE/description.md
+++ b/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_DEBUG_MODE/description.md
@@ -1,0 +1,32 @@
+GraphQL Debug Mode is a feature that, when enabled, provides detailed error messages and stack traces in responses. While this is invaluable during development, leaving it enabled in a production environment can potentially expose sensitive information about the server's internal structure and implementation details.
+
+When debug mode is enabled, error responses may include:
+- Detailed stack traces
+- Database query information
+- Internal server paths and file names
+- Sensitive configuration details
+
+Example of a response with debug mode enabled:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Cannot query field \"nonexistentField\" on type \"Query\".",
+      "locations": [
+        {
+          "line": 3,
+          "column": 3
+        }
+      ],
+      "stack": "GraphQLError: Cannot query field \"nonexistentField\" on type \"Query\".\n    at validateField (/app/node_modules/graphql/validation/rules/FieldsOnCorrectTypeRule.js:48:31)\n    at ..."
+    }
+  ],
+  "data": null
+}
+```
+
+Security Impact of GraphQL Debug Mode:
+- **Information Disclosure**: Debug information can reveal internal details about the GraphQL server's structure, dependencies, and potential vulnerabilities, which could be leveraged by attackers to plan more targeted attacks.
+- **Sensitive Data Exposure**: Stack traces and error messages might inadvertently include sensitive information such as database queries, internal file paths, or environment variables.
+- **Easier Exploitation**: Detailed error messages can assist attackers in refining their attacks by providing immediate feedback on what worked or didn't work in their malicious queries.

--- a/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_DEBUG_MODE/meta.json
+++ b/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_DEBUG_MODE/meta.json
@@ -1,0 +1,28 @@
+{
+  "risk_rating": "medium",
+  "title": "GraphQL Debug Mode Enabled",
+  "short_description": "GraphQL debug mode is enabled, which may expose sensitive information through detailed error messages and stack traces.",
+  "references": {
+    "OWASP": "https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html#debug-mode",
+    "Apollo GraphQL": "https://www.apollographql.com/docs/apollo-server/data/errors/"
+  },
+  "privacy_issue": true,
+  "security_issue": true,
+  "categories": {
+    "PCI_STANDARDS": [
+      "REQ_6_5",
+      "REQ_11_3"
+    ],
+    "OWASP_MASVS_L2": [
+      "MSTG_ARCH_9"
+    ],
+    "OWASP_ASVS_L3": [
+      "V7_4_1"
+    ],
+    "SOC2_CONTROLS": [
+      "CC_6_1",
+      "CC_6_7",
+      "CC_7_1"
+    ]
+  }
+}

--- a/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_DEBUG_MODE/recommendation.md
+++ b/WEB_SERVICE/WEB/_MEDIUM/GRAPHQL_DEBUG_MODE/recommendation.md
@@ -1,0 +1,55 @@
+To mitigate the risks associated with GraphQL Debug Mode, consider the following recommendations:
+
+1. **Disable Debug Mode in Production**: Ensure that GraphQL debug mode is disabled in production environments. Debug information should only be available in development and testing environments.
+
+2. **Use Environment-Specific Configuration**: Implement environment-specific configuration to ensure debug mode is automatically disabled in production deployments.
+
+3. **Implement Custom Error Handling**: Create a custom error handling mechanism that sanitizes error messages before sending them to clients in production. This should remove any sensitive information while still providing useful feedback.
+
+4. **Use Error Masking**: Implement error masking to replace detailed error messages with generic ones in production environments.
+
+5. **Implement Proper Logging**: Instead of relying on debug mode for error tracking, implement proper logging mechanisms that securely store detailed error information for later analysis.
+
+6. **Regular Security Audits**: Conduct regular security audits to ensure that debug mode is not inadvertently enabled in production environments.
+
+Example of implementing custom error handling in Apollo Server:
+
+=== "javascript"
+
+```javascript
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  formatError: (error) => {
+    // Log the detailed error internally
+    console.error('Detailed error:', error);
+
+    // Return a sanitized error to the client
+    return new Error('An error occurred');
+  },
+});
+```
+
+=== "Python"
+
+```python
+from graphene import Schema
+from graphql import GraphQLError
+
+class CustomSchema(Schema):
+    def execute(self, *args, **kwargs):
+        result = super().execute(*args, **kwargs)
+        if result.errors:
+            # Log the detailed errors internally
+            for error in result.errors:
+                print(f"Detailed error: {error}")
+
+            # Replace the detailed errors with a generic message
+            result.errors = [GraphQLError("An error occurred")]
+        return result
+
+schema = CustomSchema(query=Query, mutation=Mutation)
+result = schema.execute(query)
+```
+
+For other GraphQL server implementations, consult the specific documentation on how to disable debug mode or implement custom error handling.


### PR DESCRIPTION
# Add KB Entries for GraphQL Debug Mode and Tracing

## Description
This PR adds two new Knowledge Base (KB) entries to address security concerns related to GraphQL implementations:
1. GraphQL Debug Mode Enabled
2. GraphQL Tracing Enabled

These entries provide detailed information about the risks associated with leaving debug mode and tracing enabled in production environments, along with recommendations for mitigation.

## Changes
- Added `debug_mode_enabled` KB entry
  - Description of the issue and its security impact
  - Meta information including risk rating and relevant security standards
  - Recommendations for mitigation, including code examples in JavaScript and Python
- Added `tracing_enabled` KB entry
  - Description of the issue and its security impact
  - Meta information including risk rating and relevant security standards
  - Recommendations for mitigation, including code examples in JavaScript and Python
