### PR TITLE
Add ALPACA Attack SSL

### DIFF
--- a/WEB_SERVICE/WEB/_HIGH/SSL_ALPACA_ATTACK/description.md
+++ b/WEB_SERVICE/WEB/_HIGH/SSL_ALPACA_ATTACK/description.md
@@ -1,0 +1,17 @@
+The ALPACA (Application Layer Protocol Confusion Attack) exploits weaknesses in the implementation of SSL/TLS services across multiple protocols. In this attack, an adversary can use cross-protocol attacks to redirect traffic from one protocol to another, such as HTTP to FTP, allowing for man-in-the-middle (MITM) attacks and potential exploitation of the protocol mismatches.
+
+Key security impacts of ALPACA include:
+
+* Man-in-the-middle (MITM) attacks: Attackers can intercept and manipulate traffic between a client and a server by redirecting requests to an unintended service.
+* Cross-protocol confusion: By redirecting requests between different protocols, attackers can exploit differences in how protocols handle requests, leading to sensitive data exposure or unauthorized access.
+* Service impersonation: Attackers can trick a client into connecting to a different service, such as making an HTTPS request to an FTP server, resulting in data leakage or credential theft.
+* Confidentiality and integrity compromise: Sensitive data transmitted over what is assumed to be a secure channel may be intercepted and altered.
+
+ALPACA requires the target service to be using valid SSL/TLS certificates but allows attackers to manipulate the intended destination by exploiting how certain protocols handle secure connections.
+
+Example of a redirection scenario:
+
+* An attacker forces a victim's HTTPS request to be interpreted by an FTP service, exploiting the differences between the two protocols.
+* The FTP server may interpret parts of the request differently, potentially allowing the attacker to manipulate the data exchange.
+
+This attack primarily affects services that improperly handle cross-protocol traffic or do not restrict protocol use in SSL/TLS configurations.

--- a/WEB_SERVICE/WEB/_HIGH/SSL_ALPACA_ATTACK/meta.json
+++ b/WEB_SERVICE/WEB/_HIGH/SSL_ALPACA_ATTACK/meta.json
@@ -1,0 +1,63 @@
+{
+  "title": "ALPACA Attack in SSL/TLS",
+  "short_description": "Cross-protocol confusion attack in SSL/TLS allowing for man-in-the-middle and service impersonation attacks by redirecting traffic between different protocols.",
+  "risk_rating": "high",
+  "references": {
+    "ALPACA Research Paper": "https://alpaca-attack.com/ALPACA.pdf",
+    "Cross-Protocol MITM Attack": "https://var.thejh.net/http_ftp_cross_protocol_mitm_attacks.pdf",
+    "ALPACA Code": "https://github.com/RUB-NDS/alpaca-code"
+  },
+  "privacy_issue": false,
+  "security_issue": true,
+  "categories": {
+    "SOC2_CONTROLS": [
+      "CC_3_2",
+      "CC_3_3",
+      "CC_5_1",
+      "CC_5_2",
+      "CC_6_1",
+      "CC_6_8",
+      "CC_7_1",
+      "CC_7_2"
+    ],
+    "PCI_STANDARDS":[
+      "REQ_3_2",
+      "REQ_3_3",
+      "REQ_3_4",
+      "REQ_3_5",
+      "REQ_3_6",
+      "REQ_4_1",
+      "REQ_4_2",
+      "REQ_6_3",
+      "REQ_6_4",
+      "REQ_7_1",
+      "REQ_7_2",
+      "REQ_7_3",
+      "REQ_11_3",
+      "REQ_11_4",
+      "REQ_12_1",
+      "REQ_12_3"
+    ],
+    "CCPA": [
+      "CCPA_1798_100",
+      "CCPA_1798_105",
+      "CCPA_1798_110",
+      "CCPA_1798_115",
+      "CCPA_1798_120",
+      "CCPA_1798_125",
+      "CCPA_1798_130",
+      "CCPA_1798_135",
+      "CCPA_1798_140",
+      "CCPA_1798_150"
+    ],
+    "CWE_TOP_25" : [
+      "CWE_287",
+      "CWE_798",
+      "CWE_79",
+      "CWE_352",
+      "CWE_20",
+      "CWE_306",
+      "CWE_119"
+    ]
+  }
+}

--- a/WEB_SERVICE/WEB/_HIGH/SSL_ALPACA_ATTACK/recommendation.md
+++ b/WEB_SERVICE/WEB/_HIGH/SSL_ALPACA_ATTACK/recommendation.md
@@ -1,0 +1,16 @@
+To mitigate ALPACA attacks in SSL/TLS configurations, follow these recommendations:
+
+1. **Restrict SSL/TLS to a Single Protocol**: Ensure that each service, such as HTTP, FTP, SMTP, and others, uses SSL/TLS exclusively for that protocol. Avoid allowing multiple protocols to share the same SSL/TLS certificates unless absolutely necessary.
+
+2. **Disable Unnecessary Protocols**: If services do not need to support certain protocols (e.g., FTP over TLS), disable them entirely to prevent cross-protocol attacks.
+
+3. **Enforce Strict Protocol Handling**: Implement protocol-specific protections that reject cross-protocol handshakes. For example, ensure that an HTTPS server rejects requests that appear to come from FTP clients.
+
+4. **Service Separation**: Avoid using the same domain and certificate for multiple services or protocols. Separate services by using different domains or subdomains with distinct certificates to avoid confusion.
+
+5. **Harden SSL/TLS Configuration**:
+   * Disable weak cipher suites and protocols (e.g., SSLv2, SSLv3).
+   * Enable strict TLS version enforcement to prevent downgrade attacks.
+   * Regularly update SSL/TLS libraries to patch known vulnerabilities.
+
+By ensuring strict separation of protocols and proper SSL/TLS configurations, organizations can prevent ALPACA attacks and secure their services from cross-protocol vulnerabilities.


### PR DESCRIPTION
# Add ALPACA Attack SSL KB

Adds documentation for the ALPACA (Application Layer Protocol Confusion Attack) vulnerability in SSL/TLS.

## Changes
- Add description, metadata, and recommendations for ALPACA attack
- Risk Rating: High
- Impacts: MITM attacks, cross-protocol confusion, service impersonation
- Affects multiple compliance standards (SOC2, PCI-DSS, CCPA)

Key mitigation: Restrict SSL/TLS to single protocols, disable unnecessary protocols, harden SSL/TLS configs.