### PR TITLE
Rename KB title to avoid duplication & Fix risk ratings

### DIFF
--- a/MOBILE_CLIENT/COMMON/_HIGH/INSECURE_REPUTATION/meta.json
+++ b/MOBILE_CLIENT/COMMON/_HIGH/INSECURE_REPUTATION/meta.json
@@ -6,7 +6,7 @@
         "AbuseIPDB" : "https://www.abuseipdb.com/",
         "GoogleSaveBrowsing" : "https://safebrowsing.google.com/"
     },
-    "title": "Insecure domain name and IP address reputation report",
+    "title": "Domain name and IP address reputation report",
     "privacy_issue": false,
     "security_issue": true,
     "categories": {

--- a/MOBILE_CLIENT/COMMON/_HIGH/INSECURE_REPUTATION/meta.json
+++ b/MOBILE_CLIENT/COMMON/_HIGH/INSECURE_REPUTATION/meta.json
@@ -6,7 +6,7 @@
         "AbuseIPDB" : "https://www.abuseipdb.com/",
         "GoogleSaveBrowsing" : "https://safebrowsing.google.com/"
     },
-    "title": "Domain name and IP address reputation report",
+    "title": "Insecure domain name and IP address reputation report",
     "privacy_issue": false,
     "security_issue": true,
     "categories": {

--- a/MOBILE_CLIENT/COMMON/_MEDIUM/COLLECTION_OF_USERS_TEXT_MESSAGES_WITHOUT_CONSENT/meta.json
+++ b/MOBILE_CLIENT/COMMON/_MEDIUM/COLLECTION_OF_USERS_TEXT_MESSAGES_WITHOUT_CONSENT/meta.json
@@ -1,5 +1,5 @@
 {
-    "risk_rating": "high",
+    "risk_rating": "medium",
     "short_description": "Privacy policy mentions collection of users' text messages without explicit consent",
     "references": {
         "Android Privacy Guidelines": "https://developer.android.com/privacy-and-security/about",

--- a/MOBILE_CLIENT/COMMON/_SECURE/COLLECTION_OF_USERS_CRASH_LOGS_WITH_CONSENT/meta.json
+++ b/MOBILE_CLIENT/COMMON/_SECURE/COLLECTION_OF_USERS_CRASH_LOGS_WITH_CONSENT/meta.json
@@ -7,7 +7,7 @@
     "Apple Privacy Manifest": "https://developer.apple.com/documentation/bundleresources/privacy_manifest_files",
     "CWE-359: Exposure of Private Information (\"Privacy Violation\")": "http://cwe.mitre.org/data/definitions/359.html"
   },
-  "title": "Collection of Users' Crash Logs without Consent",
+  "title": "Secure Collection of Users' Crash Logs without Consent",
   "privacy_issue": true,
   "security_issue": false,
   "categories": {}

--- a/MOBILE_CLIENT/COMMON/_SECURE/COLLECTION_OF_USERS_PURCHASE_HISTORY_WITH_CONSENT/meta.json
+++ b/MOBILE_CLIENT/COMMON/_SECURE/COLLECTION_OF_USERS_PURCHASE_HISTORY_WITH_CONSENT/meta.json
@@ -7,7 +7,7 @@
         "Apple Privacy Manifest": "https://developer.apple.com/documentation/bundleresources/privacy_manifest_files",
         "CWE-359: Exposure of Private Information (\"Privacy Violation\")": "http://cwe.mitre.org/data/definitions/359.html"
     },
-    "title": "Collection of Users' Purchase History in Privacy Policy",
+    "title": "Secure Collection of Users' Purchase History in Privacy Policy",
     "privacy_issue": true,
     "security_issue": false,
     "categories": {}

--- a/MOBILE_CLIENT/COMMON/_SECURE/COLLECTION_OF_USERS_TEXT_MESSAGES_WITH_CONSENT/meta.json
+++ b/MOBILE_CLIENT/COMMON/_SECURE/COLLECTION_OF_USERS_TEXT_MESSAGES_WITH_CONSENT/meta.json
@@ -1,5 +1,5 @@
 {
-    "risk_rating": "high",
+    "risk_rating": "secure",
     "short_description": "Privacy policy mentions collection of users' text messages with consent",
     "references": {
         "Android Privacy Guidelines": "https://developer.android.com/privacy-and-security/about",
@@ -7,7 +7,7 @@
         "Apple Privacy Manifest": "https://developer.apple.com/documentation/bundleresources/privacy_manifest_files",
         "CWE-359: Exposure of Private Information (\"Privacy Violation\")": "http://cwe.mitre.org/data/definitions/359.html"
     },
-    "title": "Collection of Users' Text Messages in Privacy Policy",
+    "title": "Secure Collection of Users' Text Messages in Privacy Policy",
     "privacy_issue": true,
     "security_issue": false,
     "categories": {}

--- a/MOBILE_CLIENT/COMMON/_SECURE/INAPP_SEARCH_HISTORY_COLLECTION_WITH_CONSENT/meta.json
+++ b/MOBILE_CLIENT/COMMON/_SECURE/INAPP_SEARCH_HISTORY_COLLECTION_WITH_CONSENT/meta.json
@@ -1,5 +1,5 @@
 {
-    "risk_rating": "high",
+    "risk_rating": "secure",
     "short_description": "Privacy policy mentions collection of users' in-app search history with consent",
     "references": {
         "Android Privacy Guidelines": "https://developer.android.com/privacy-and-security/about",
@@ -7,7 +7,7 @@
         "Apple Privacy Manifest": "https://developer.apple.com/documentation/bundleresources/privacy_manifest_files",
         "CWE-359: Exposure of Private Information (\"Privacy Violation\")": "http://cwe.mitre.org/data/definitions/359.html"
     },
-    "title": "In-App Search History Collection in Privacy Policy",
+    "title": "Secure In-App Search History Collection in Privacy Policy",
     "privacy_issue": true,
     "security_issue": false,
     "categories": {}

--- a/MOBILE_CLIENT/COMMON/_SECURE/SECURE_REPUTATION/meta.json
+++ b/MOBILE_CLIENT/COMMON/_SECURE/SECURE_REPUTATION/meta.json
@@ -6,7 +6,7 @@
         "AbuseIPDB" : "https://www.abuseipdb.com/",
         "GoogleSaveBrowsing" : "https://safebrowsing.google.com/"
     },
-    "title": "Domain name and IP address reputation report",
+    "title": "Secure domain name and IP address reputation report",
     "privacy_issue": false,
     "security_issue": false
 }

--- a/MOBILE_CLIENT/COMMON/_SECURE/USER_ID_COLLECTION_IN_PRIVACY_POLICY_MATCH/meta.json
+++ b/MOBILE_CLIENT/COMMON/_SECURE/USER_ID_COLLECTION_IN_PRIVACY_POLICY_MATCH/meta.json
@@ -7,7 +7,7 @@
     "Apple Privacy Manifest": "https://developer.apple.com/documentation/bundleresources/privacy_manifest_files",
     "CWE-359: Exposure of Private Information (\"Privacy Violation\")": "http://cwe.mitre.org/data/definitions/359.html"
   },
-  "title": "User ID Collection in Privacy Policy",
+  "title": "Secure User ID Collection in Privacy Policy",
   "privacy_issue": true,
   "security_issue": false,
   "categories": {}


### PR DESCRIPTION
In this PR:

- Fixed the risk rating.
- Renamed the titles of secure KBs that share the same title with another KBs to avoid duplication by adding "Secure" at the beginning of the title.