### PR TITLE
fix: invalid link in references of apk list

### DIFF
--- a/MOBILE_CLIENT/ANDROID/_INFO/APK_FILE_LIST/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_INFO/APK_FILE_LIST/meta.json
@@ -2,7 +2,7 @@
   "risk_rating": "info",
   "short_description": "List of all files shipped in the application.",
   "references": {
-    "Inside the Android Application Framework (Google I/O 2008)": "https://sites.google.com/site/io/inside-the-android-application-framework",
+    "Guide to app architecture (Android Developer)": "https://developer.android.com/topic/architecture",
     "Android Application Package (Wikipedia)": "https://en.wikipedia.org/wiki/Android_application_package"
   },
   "title": "APK files list",


### PR DESCRIPTION
The pytest tests were failing for this PR: https://github.com/Ostorlab/KB/pull/230

The issue was that a referenced link is no longer available on the internet:  
[[Inside the Android Application Framework](https://sites.google.com/site/io/inside-the-android-application-framework)](https://sites.google.com/site/io/inside-the-android-application-framework).  

### Solution:  
Use [Android Architecture](https://developer.android.com/topic/architecture) as the reference instead of the outdated Google Sites link.  