### PR TITLE
fix: Increase reference liveness test timeout to 30 seconds

### DIFF
--- a/tests/kb_test.py
+++ b/tests/kb_test.py
@@ -1157,7 +1157,7 @@ def testMetaFiles_always_referencesShouldHaveValidLinks() -> None:
                     invalid_urls.add(url)
             else:
                 try:
-                    response = requests.get(url, timeout=5)
+                    response = requests.get(url, timeout=30)
                     is_valid = response.status_code < 404
                 except requests.RequestException:
                     is_valid = False


### PR DESCRIPTION
The pytest tests were failing for this PR: https://github.com/Ostorlab/KB/pull/231.  

The issue was that the request timed out on many servers, causing the tests to fail.  
![image](https://github.com/user-attachments/assets/4c8d4c3d-4a00-4311-87e3-da4be1ea4072)

**Solution:**  
Increase the timeout when checking the liveness of a reference.

