### PR TITLE
fix: Set privacy issue to false in the Cryptoobject usage static rule

### DIFF
--- a/MOBILE_CLIENT/COMMON/_HIGH/BIOMETRIC_AUTH_WITHOUT_CRYPTOGRAPHIC_BINDING/meta.json
+++ b/MOBILE_CLIENT/COMMON/_HIGH/BIOMETRIC_AUTH_WITHOUT_CRYPTOGRAPHIC_BINDING/meta.json
@@ -7,7 +7,7 @@
     "iOS Secure Enclave":"https://support.apple.com/guide/security/secure-enclave-sec59b0b31ff/web"
   },
   "title":"Biometric Authentication Without Cryptographic Binding",
-  "privacy_issue":true,
+  "privacy_issue":false,
   "security_issue":true,
   "categories":{
       "OWASP_MASVS_L1":[


### PR DESCRIPTION
Set the privacy issue tag to false for the `Biometric Authentication Without Cryptographic Binding` KB entry