### PR TITLE
feature: TLS CCS Injection

### DIFF
--- a/WEB_SERVICE/TLS/_HIGH/TLS_CCS_INJECTION/description.md
+++ b/WEB_SERVICE/TLS/_HIGH/TLS_CCS_INJECTION/description.md
@@ -1,0 +1,19 @@
+This vulnerability indicates that the server is susceptible to CCS injection attacks, which exploit improper handling of ChangeCipherSpec messages in OpenSSL to force the use of weak encryption keys during TLS handshakes.
+
+CCS (ChangeCipherSpec) injection occurs when OpenSSL accepts CCS messages out of order, before the master secret has been properly established. This causes the system to generate encryption keys using an empty master secret instead of the actual negotiated secret, resulting in weak, predictable keys.
+
+### How It Works:
+1. Attacker intercepts TLS handshake after ServerHello but before master secret generation
+2. Malicious CCS message is injected into both client and server connections
+3. Both endpoints generate session keys using empty master secret (all zeros)
+4. Attacker can decrypt all subsequent traffic using the predictable weak keys
+
+### Requirements:
+- Both client and server must use vulnerable OpenSSL versions
+- Man-in-the-middle network access capability
+- OpenSSL 1.0.1+ servers are particularly exploitable
+
+**Example Scenario:**
+A web application uses OpenSSL 1.0.1g on both client and server. An attacker on the same network injects CCS messages during the TLS handshake, forcing both sides to use encryption keys derived from an empty master secret. The attacker can then decrypt all HTTPS traffic, including login credentials and session cookies.
+
+The vulnerability existed in OpenSSL for over 15 years before discovery, affecting virtually all SSL/TLS connections using vulnerable OpenSSL versions and enabling complete session compromise.

--- a/WEB_SERVICE/TLS/_HIGH/TLS_CCS_INJECTION/meta.json
+++ b/WEB_SERVICE/TLS/_HIGH/TLS_CCS_INJECTION/meta.json
@@ -3,7 +3,6 @@
   "short_description": "OpenSSL ChangeCipherSpec injection vulnerability allowing man-in-the-middle attacks through forced use of weak encryption keys.",
   "references": {
     "CVE-2014-0224": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0224",
-    "OpenSSL Security Advisory": "https://www.openssl.org/news/secadv_20140605.txt",
     "Technical Analysis": "https://www.imperialviolet.org/2014/06/05/earlyccs.html"
   },
   "title": "CCS Injection Attack on OpenSSL",

--- a/WEB_SERVICE/TLS/_HIGH/TLS_CCS_INJECTION/meta.json
+++ b/WEB_SERVICE/TLS/_HIGH/TLS_CCS_INJECTION/meta.json
@@ -1,0 +1,29 @@
+{
+  "risk_rating": "high",
+  "short_description": "OpenSSL ChangeCipherSpec injection vulnerability allowing man-in-the-middle attacks through forced use of weak encryption keys.",
+  "references": {
+    "CVE-2014-0224": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0224",
+    "OpenSSL Security Advisory": "https://www.openssl.org/news/secadv_20140605.txt",
+    "Technical Analysis": "https://www.imperialviolet.org/2014/06/05/earlyccs.html"
+  },
+  "title": "CCS Injection Attack on OpenSSL",
+  "privacy_issue": true,
+  "security_issue": true,
+  "categories": {
+    "SOC2_CONTROLS": [
+      "CC_6_7",
+      "CC_7_1"
+    ],
+    "CCPA": [
+      "CCPA_1798_150"
+    ],
+    "GDPR": [
+      "ART_32"
+    ],
+    "PCI_STANDARDS": [
+      "REQ_4_1",
+      "REQ_6_2",
+      "REQ_11_3"
+    ]
+  }
+}

--- a/WEB_SERVICE/TLS/_HIGH/TLS_CCS_INJECTION/recommendation.md
+++ b/WEB_SERVICE/TLS/_HIGH/TLS_CCS_INJECTION/recommendation.md
@@ -1,0 +1,45 @@
+To mitigate CCS injection attacks:
+
+**Primary Defense - Update OpenSSL:**
+
+Update to patched OpenSSL versions immediately:
+- OpenSSL 1.0.1h or later
+- OpenSSL 1.0.0m or later  
+- OpenSSL 0.9.8za or later
+
+```bash
+# Check current version
+openssl version
+
+# Update packages
+apt-get update && apt-get upgrade openssl  # Debian/Ubuntu
+yum update openssl                         # RHEL/CentOS
+```
+
+**Restart Services:**
+
+After updating, restart all services using OpenSSL:
+```bash
+systemctl restart apache2    # or nginx, postfix, etc.
+systemctl restart postfix
+systemctl restart dovecot
+```
+
+**Testing for Vulnerability:**
+
+```bash
+# Test server for CCS injection vulnerability
+openssl s_client -connect example.com:443 -msg 2>&1 | grep -i "early ccs"
+
+# Use SSL Labs test
+curl "https://api.ssllabs.com/api/v3/analyze?host=example.com"
+```
+
+**Additional Mitigations:**
+
+* Monitor network traffic for unusual CCS message patterns
+* Implement certificate pinning where possible to detect MITM attempts
+* Use non-OpenSSL TLS implementations (NSS, GnuTLS) for critical applications
+* Enable perfect forward secrecy to limit damage from key compromise
+
+CCS injection does not expose private keys or certificates, so certificate replacement is not required after patching.


### PR DESCRIPTION
This vulnerability indicates that the server is susceptible to CCS injection attacks, which exploit improper handling of ChangeCipherSpec messages in OpenSSL to force the use of weak encryption keys during TLS handshakes.

CCS (ChangeCipherSpec) injection occurs when OpenSSL accepts CCS messages out of order, before the master secret has been properly established. This causes the system to generate encryption keys using an empty master secret instead of the actual negotiated secret, resulting in weak, predictable keys.

### How It Works:
1. Attacker intercepts TLS handshake after ServerHello but before master secret generation
2. Malicious CCS message is injected into both client and server connections
3. Both endpoints generate session keys using empty master secret (all zeros)
4. Attacker can decrypt all subsequent traffic using the predictable weak keys

### Requirements:
- Both client and server must use vulnerable OpenSSL versions
- Man-in-the-middle network access capability
- OpenSSL 1.0.1+ servers are particularly exploitable

**Example Scenario:**
A web application uses OpenSSL 1.0.1g on both client and server. An attacker on the same network injects CCS messages during the TLS handshake, forcing both sides to use encryption keys derived from an empty master secret. The attacker can then decrypt all HTTPS traffic, including login credentials and session cookies.

The vulnerability existed in OpenSSL for over 15 years before discovery, affecting virtually all SSL/TLS connections using vulnerable OpenSSL versions and enabling complete session compromise.

```json
{
  "risk_rating": "high",
  "short_description": "OpenSSL ChangeCipherSpec injection vulnerability allowing man-in-the-middle attacks through forced use of weak encryption keys.",
  "references": {
    "CVE-2014-0224": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0224",
    "Technical Analysis": "https://www.imperialviolet.org/2014/06/05/earlyccs.html"
  },
  "title": "CCS Injection Attack on OpenSSL",
  "privacy_issue": true,
  "security_issue": true,
  "categories": {
    "SOC2_CONTROLS": [
      "CC_6_7",
      "CC_7_1"
    ],
    "CCPA": [
      "CCPA_1798_150"
    ],
    "GDPR": [
      "ART_32"
    ],
    "PCI_STANDARDS": [
      "REQ_4_1",
      "REQ_6_2",
      "REQ_11_3"
    ]
  }
}
```
To mitigate CCS injection attacks:

**Primary Defense - Update OpenSSL:**

Update to patched OpenSSL versions immediately:
- OpenSSL 1.0.1h or later
- OpenSSL 1.0.0m or later  
- OpenSSL 0.9.8za or later

```bash
# Check current version
openssl version

# Update packages
apt-get update && apt-get upgrade openssl  # Debian/Ubuntu
yum update openssl                         # RHEL/CentOS
```

**Restart Services:**

After updating, restart all services using OpenSSL:
```bash
systemctl restart apache2    # or nginx, postfix, etc.
systemctl restart postfix
systemctl restart dovecot
```

**Testing for Vulnerability:**

```bash
# Test server for CCS injection vulnerability
openssl s_client -connect example.com:443 -msg 2>&1 | grep -i "early ccs"

# Use SSL Labs test
curl "https://api.ssllabs.com/api/v3/analyze?host=example.com"
```

**Additional Mitigations:**

* Monitor network traffic for unusual CCS message patterns
* Implement certificate pinning where possible to detect MITM attempts
* Use non-OpenSSL TLS implementations (NSS, GnuTLS) for critical applications
* Enable perfect forward secrecy to limit damage from key compromise

CCS injection does not expose private keys or certificates, so certificate replacement is not required after patching.