### PR TITLE
feature: TLS Ticketbleed

### DIFF
--- a/WEB_SERVICE/TLS/_MEDIUM/TLS_TICKETBLEED/description.md
+++ b/WEB_SERVICE/TLS/_MEDIUM/TLS_TICKETBLEED/description.md
@@ -1,0 +1,19 @@
+This vulnerability indicates that the server is susceptible to Ticketbleed attacks, which exploit improper session ticket handling in F5 BIG-IP appliances to leak uninitialized memory containing sensitive data.
+
+Ticketbleed occurs when F5 TLS implementations incorrectly handle session ID lengths during TLS session resumption. When a client sends a session ID shorter than 32 bytes, the server allocates a buffer of the correct size but always returns 32 bytes, exposing uninitialized memory in the padding.
+
+### How It Works:
+1. Client sends TLS session ticket with session ID shorter than 32 bytes (e.g., 16 bytes)
+2. F5 server allocates buffer matching client's session ID length
+3. Server responds with fixed 32-byte session ID, padding with uninitialized memory
+4. Attacker extracts up to 31 bytes of memory per request containing sensitive data
+
+### Requirements:
+- F5 BIG-IP appliance with session tickets enabled (non-default setting)
+- Client using non-standard session ID lengths (browsers use 32 bytes by default)
+- Remote network access to the TLS service
+
+**Example Scenario:**
+A company uses F5 BIG-IP load balancers with session tickets enabled. An application using the Go TLS library connects with 16-byte session IDs. Each connection leaks 16 bytes of server memory, potentially exposing SSL session data, encryption keys, or other sensitive information from previous connections.
+
+The vulnerability affects only F5 proprietary TLS stack, not OpenSSL, and exposes 31 bytes at a time compared to Heartbleed's 64KB, requiring more requests to extract significant data but still enabling complete session compromise.

--- a/WEB_SERVICE/TLS/_MEDIUM/TLS_TICKETBLEED/meta.json
+++ b/WEB_SERVICE/TLS/_MEDIUM/TLS_TICKETBLEED/meta.json
@@ -1,0 +1,29 @@
+{
+  "risk_rating": "medium",
+  "short_description": "F5 BIG-IP session ticket vulnerability allowing extraction of uninitialized memory through improper session ID padding.",
+  "references": {
+    "CVE-2016-9244": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9244",
+    "Ticketbleed Official Site": "https://filippo.io/Ticketbleed/",
+    "F5 Security Advisory": "https://support.f5.com/csp/article/K05121675"
+  },
+  "title": "Ticketbleed Memory Disclosure in F5 BIG-IP",
+  "privacy_issue": true,
+  "security_issue": true,
+  "categories": {
+    "SOC2_CONTROLS": [
+      "CC_6_7",
+      "CC_7_1"
+    ],
+    "CCPA": [
+      "CCPA_1798_150"
+    ],
+    "GDPR": [
+      "ART_32"
+    ],
+    "PCI_STANDARDS": [
+      "REQ_4_1",
+      "REQ_6_2",
+      "REQ_11_3"
+    ]
+  }
+}

--- a/WEB_SERVICE/TLS/_MEDIUM/TLS_TICKETBLEED/recommendation.md
+++ b/WEB_SERVICE/TLS/_MEDIUM/TLS_TICKETBLEED/recommendation.md
@@ -1,0 +1,41 @@
+To mitigate Ticketbleed attacks:
+
+**Primary Defense - Update F5 TMOS:**
+
+Upgrade to patched F5 BIG-IP versions:
+- 11.6.0 HF6 or later
+- 12.0.0 HF4 or later  
+- 12.1.0 HF1 or later
+- 13.0.0 or later
+
+**Immediate Mitigation - Disable Session Tickets:**
+
+If immediate patching is not possible, disable session tickets on affected SSL profiles:
+
+```bash
+# Via F5 CLI
+tmsh modify ltm profile client-ssl [profile-name] options none
+
+# Via F5 Web Interface
+Local Traffic > Profiles > SSL > Client > [Profile] > Configuration > Options
+Remove "Session Ticket" from enabled options
+```
+
+**Testing for Vulnerability:**
+
+```bash
+# Test with custom session ID length
+openssl s_client -connect target:443 -sess_out session.pem
+openssl s_client -connect target:443 -sess_in session.pem -msg
+
+# Check SSL Labs test results
+curl "https://api.ssllabs.com/api/v3/analyze?host=target.com"
+```
+
+**Detection and Monitoring:**
+
+* Monitor for unusual session ID patterns in TLS handshakes
+* Look for connections with non-standard session ID lengths (not 32 bytes)
+* F5 devices log session ticket usage when debug logging is enabled
+
+This vulnerability only affects F5 BIG-IP appliances with session tickets explicitly enabled. Standard web browsers are not affected as they use 32-byte session IDs by default.


### PR DESCRIPTION
This vulnerability indicates that the server is susceptible to Ticketbleed attacks, which exploit improper session ticket handling in F5 BIG-IP appliances to leak uninitialized memory containing sensitive data.

Ticketbleed occurs when F5 TLS implementations incorrectly handle session ID lengths during TLS session resumption. When a client sends a session ID shorter than 32 bytes, the server allocates a buffer of the correct size but always returns 32 bytes, exposing uninitialized memory in the padding.

### How It Works:
1. Client sends TLS session ticket with session ID shorter than 32 bytes (e.g., 16 bytes)
2. F5 server allocates buffer matching client's session ID length
3. Server responds with fixed 32-byte session ID, padding with uninitialized memory
4. Attacker extracts up to 31 bytes of memory per request containing sensitive data

### Requirements:
- F5 BIG-IP appliance with session tickets enabled (non-default setting)
- Client using non-standard session ID lengths (browsers use 32 bytes by default)
- Remote network access to the TLS service

**Example Scenario:**
A company uses F5 BIG-IP load balancers with session tickets enabled. An application using the Go TLS library connects with 16-byte session IDs. Each connection leaks 16 bytes of server memory, potentially exposing SSL session data, encryption keys, or other sensitive information from previous connections.

The vulnerability affects only F5 proprietary TLS stack, not OpenSSL, and exposes 31 bytes at a time compared to Heartbleed's 64KB, requiring more requests to extract significant data but still enabling complete session compromise.
```json
{
  "risk_rating": "medium",
  "short_description": "F5 BIG-IP session ticket vulnerability allowing extraction of uninitialized memory through improper session ID padding.",
  "references": {
    "CVE-2016-9244": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-9244",
    "Ticketbleed Official Site": "https://filippo.io/Ticketbleed/",
    "F5 Security Advisory": "https://support.f5.com/csp/article/K05121675"
  },
  "title": "Ticketbleed Memory Disclosure in F5 BIG-IP",
  "privacy_issue": true,
  "security_issue": true,
  "categories": {
    "SOC2_CONTROLS": [
      "CC_6_7",
      "CC_7_1"
    ],
    "CCPA": [
      "CCPA_1798_150"
    ],
    "GDPR": [
      "ART_32"
    ],
    "PCI_STANDARDS": [
      "REQ_4_1",
      "REQ_6_2",
      "REQ_11_3"
    ]
  }
}
```

To mitigate Ticketbleed attacks:

**Primary Defense - Update F5 TMOS:**

Upgrade to patched F5 BIG-IP versions:
- 11.6.0 HF6 or later
- 12.0.0 HF4 or later  
- 12.1.0 HF1 or later
- 13.0.0 or later

**Immediate Mitigation - Disable Session Tickets:**

If immediate patching is not possible, disable session tickets on affected SSL profiles:

```bash
# Via F5 CLI
tmsh modify ltm profile client-ssl [profile-name] options none

# Via F5 Web Interface
Local Traffic > Profiles > SSL > Client > [Profile] > Configuration > Options
Remove "Session Ticket" from enabled options
```

**Testing for Vulnerability:**

```bash
# Test with custom session ID length
openssl s_client -connect target:443 -sess_out session.pem
openssl s_client -connect target:443 -sess_in session.pem -msg

# Check SSL Labs test results
curl "https://api.ssllabs.com/api/v3/analyze?host=target.com"
```

**Detection and Monitoring:**

* Monitor for unusual session ID patterns in TLS handshakes
* Look for connections with non-standard session ID lengths (not 32 bytes)
* F5 devices log session ticket usage when debug logging is enabled

This vulnerability only affects F5 BIG-IP appliances with session tickets explicitly enabled. Standard web browsers are not affected as they use 32-byte session IDs by default.