### PR TITLE
feature: TLS Insecure Renego

### DIFF
--- a/WEB_SERVICE/TLS/_MEDIUM/TLS_INSECURE_RENEGOTIATION/description.md
+++ b/WEB_SERVICE/TLS/_MEDIUM/TLS_INSECURE_RENEGOTIATION/description.md
@@ -1,0 +1,19 @@
+This vulnerability indicates that the server does not support secure renegotiation as defined in RFC 5746, leaving it vulnerable to plaintext injection attacks during TLS handshake renegotiation.
+
+TLS renegotiation allows changing connection parameters during an active session. The original TLS specification failed to cryptographically bind renegotiation handshakes to existing connections, creating a security flaw where attackers can inject data into encrypted sessions.
+
+### How It Works:
+1. Attacker establishes TLS connection to target server and injects malicious requests
+2. Legitimate client attempts to connect to the same server  
+3. Attacker splices the client's handshake as a "renegotiation" of their existing session
+4. Server processes attacker's initial data in the context of the authenticated client
+
+### Requirements:
+- Server supports TLS renegotiation without RFC 5746
+- Man-in-the-middle network position 
+- Application protocols that don't distinguish pre/post-authentication data
+
+**Example Scenario:**
+An attacker on public WiFi intercepts banking connections, establishes a TLS session, and sends unauthorized transfer requests. When the victim authenticates, the server processes the malicious transfers as legitimate requests from the authenticated user.
+
+This affects HTTPS, SMTP over TLS, and other TLS-protected protocols, potentially leading to unauthorized transactions, data theft, and account compromise.

--- a/WEB_SERVICE/TLS/_MEDIUM/TLS_INSECURE_RENEGOTIATION/meta.json
+++ b/WEB_SERVICE/TLS/_MEDIUM/TLS_INSECURE_RENEGOTIATION/meta.json
@@ -1,0 +1,29 @@
+{
+  "risk_rating": "medium",
+  "short_description": "Server lacks RFC 5746 secure renegotiation support, enabling plaintext injection attacks during TLS handshake renegotiation.",
+  "references": {
+    "CVE-2009-3555": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3555",
+    "RFC 5746 - TLS Renegotiation Indication Extension": "https://datatracker.ietf.org/doc/html/rfc5746",
+    "Microsoft Security Advisory MS10-049": "https://learn.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-049"
+  },
+  "title": "Insecure TLS Renegotiation (CVE-2009-3555)",
+  "privacy_issue": true,
+  "security_issue": true,
+  "categories": {
+    "SOC2_CONTROLS": [
+      "CC_6_7",
+      "CC_7_1"
+    ],
+    "CCPA": [
+      "CCPA_1798_150"
+    ],
+    "GDPR": [
+      "ART_32"
+    ],
+    "PCI_STANDARDS": [
+      "REQ_4_1",
+      "REQ_6_2",
+      "REQ_11_3"
+    ]
+  }
+}

--- a/WEB_SERVICE/TLS/_MEDIUM/TLS_INSECURE_RENEGOTIATION/recommendation.md
+++ b/WEB_SERVICE/TLS/_MEDIUM/TLS_INSECURE_RENEGOTIATION/recommendation.md
@@ -1,0 +1,70 @@
+To mitigate insecure TLS renegotiation vulnerabilities, implement the following strategies:
+
+**Primary Mitigation - Enable RFC 5746 Support:**
+
+Upgrade your TLS implementation to support RFC 5746 (TLS Renegotiation Indication Extension). Modern versions of OpenSSL, GnuTLS, and other TLS libraries include this by default.
+
+```nginx
+# Nginx configuration (OpenSSL 1.0.1+ automatically supports RFC 5746)
+ssl_protocols TLSv1.2 TLSv1.3;
+ssl_prefer_server_ciphers on;
+```
+
+```apache
+# Apache configuration (mod_ssl with OpenSSL 1.0.1+ supports RFC 5746)
+SSLProtocol -all +TLSv1.2 +TLSv1.3
+SSLHonorCipherOrder on
+```
+
+**Alternative Mitigations:**
+
+1. **Disable Renegotiation Entirely** - If your application doesn't need renegotiation, disable it completely:
+
+```nginx
+# Nginx - renegotiation disabled by default in recent versions
+ssl_session_cache shared:SSL:10m;
+ssl_session_timeout 10m;
+```
+
+```apache
+# Apache with mod_ssl
+SSLInsecureRenegotiation off
+```
+
+2. **Upgrade to TLS 1.3** - TLS 1.3 redesigned renegotiation mechanisms to be inherently secure:
+
+```bash
+# Test server configuration
+openssl s_client -connect example.com:443 -tls1_3
+```
+
+**Testing and Verification:**
+
+```bash
+# Test for RFC 5746 support
+openssl s_client -connect example.com:443 -reconnect
+
+# Check for secure renegotiation indication
+nmap --script ssl-enum-ciphers -p 443 example.com
+```
+
+**Java Applications:**
+
+For Java applications, ensure you're using a JVM that supports RFC 5746:
+
+```bash
+# Java system property to require secure renegotiation
+-Djdk.tls.allowLegacyResumption=false
+-Djdk.tls.allowLegacyMasterSecret=false
+```
+
+**Monitoring for Attacks:**
+
+Monitor for suspicious renegotiation patterns in your TLS logs:
+
+```bash
+# Example log analysis for unusual renegotiation activity
+grep -i "renegotiation\|handshake" /var/log/nginx/error.log
+```
+
+By implementing RFC 5746 support or disabling renegotiation entirely, you eliminate the attack vector while maintaining secure TLS communications.


### PR DESCRIPTION
This vulnerability indicates that the server does not support secure renegotiation as defined in RFC 5746, leaving it vulnerable to plaintext injection attacks during TLS handshake renegotiation.

TLS renegotiation allows changing connection parameters during an active session. The original TLS specification failed to cryptographically bind renegotiation handshakes to existing connections, creating a security flaw where attackers can inject data into encrypted sessions.

### How It Works:
1. Attacker establishes TLS connection to target server and injects malicious requests
2. Legitimate client attempts to connect to the same server  
3. Attacker splices the client's handshake as a "renegotiation" of their existing session
4. Server processes attacker's initial data in the context of the authenticated client

### Requirements:
- Server supports TLS renegotiation without RFC 5746
- Man-in-the-middle network position 
- Application protocols that don't distinguish pre/post-authentication data

**Example Scenario:**
An attacker on public WiFi intercepts banking connections, establishes a TLS session, and sends unauthorized transfer requests. When the victim authenticates, the server processes the malicious transfers as legitimate requests from the authenticated user.

This affects HTTPS, SMTP over TLS, and other TLS-protected protocols, potentially leading to unauthorized transactions, data theft, and account compromise.

```json
{
  "risk_rating": "medium",
  "short_description": "Server lacks RFC 5746 secure renegotiation support, enabling plaintext injection attacks during TLS handshake renegotiation.",
  "references": {
    "CVE-2009-3555": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3555",
    "RFC 5746 - TLS Renegotiation Indication Extension": "https://datatracker.ietf.org/doc/html/rfc5746",
    "Microsoft Security Advisory MS10-049": "https://learn.microsoft.com/en-us/security-updates/securitybulletins/2010/ms10-049"
  },
  "title": "Insecure TLS Renegotiation (CVE-2009-3555)",
  "privacy_issue": true,
  "security_issue": true,
  "categories": {
    "SOC2_CONTROLS": [
      "CC_6_7",
      "CC_7_1"
    ],
    "CCPA": [
      "CCPA_1798_150"
    ],
    "GDPR": [
      "ART_32"
    ],
    "PCI_STANDARDS": [
      "REQ_4_1",
      "REQ_6_2",
      "REQ_11_3"
    ]
  }
}
```
To mitigate insecure TLS renegotiation vulnerabilities, implement the following strategies:

**Primary Mitigation - Enable RFC 5746 Support:**

Upgrade your TLS implementation to support RFC 5746 (TLS Renegotiation Indication Extension). Modern versions of OpenSSL, GnuTLS, and other TLS libraries include this by default.

```nginx
# Nginx configuration (OpenSSL 1.0.1+ automatically supports RFC 5746)
ssl_protocols TLSv1.2 TLSv1.3;
ssl_prefer_server_ciphers on;
```

```apache
# Apache configuration (mod_ssl with OpenSSL 1.0.1+ supports RFC 5746)
SSLProtocol -all +TLSv1.2 +TLSv1.3
SSLHonorCipherOrder on
```

**Alternative Mitigations:**

1. **Disable Renegotiation Entirely** - If your application doesn't need renegotiation, disable it completely:

```nginx
# Nginx - renegotiation disabled by default in recent versions
ssl_session_cache shared:SSL:10m;
ssl_session_timeout 10m;
```

```apache
# Apache with mod_ssl
SSLInsecureRenegotiation off
```

2. **Upgrade to TLS 1.3** - TLS 1.3 redesigned renegotiation mechanisms to be inherently secure:

```bash
# Test server configuration
openssl s_client -connect example.com:443 -tls1_3
```

**Testing and Verification:**

```bash
# Test for RFC 5746 support
openssl s_client -connect example.com:443 -reconnect

# Check for secure renegotiation indication
nmap --script ssl-enum-ciphers -p 443 example.com
```

**Java Applications:**

For Java applications, ensure you're using a JVM that supports RFC 5746:

```bash
# Java system property to require secure renegotiation
-Djdk.tls.allowLegacyResumption=false
-Djdk.tls.allowLegacyMasterSecret=false
```

**Monitoring for Attacks:**

Monitor for suspicious renegotiation patterns in your TLS logs:

```bash
# Example log analysis for unusual renegotiation activity
grep -i "renegotiation\|handshake" /var/log/nginx/error.log
```

By implementing RFC 5746 support or disabling renegotiation entirely, you eliminate the attack vector while maintaining secure TLS communications.