### PR TITLE
fix: fix testJsonFiles_whenFileHasCategories_shouldBeValid error object

### DIFF
--- a/tests/kb_test.py
+++ b/tests/kb_test.py
@@ -1258,7 +1258,7 @@ def testJsonFiles_whenFileHasCategories_shouldBeValid() -> None:
                 all(group_key in CATEGORY_GROUPS for group_key in categories.keys())
                 is True
             ), [
-                group_key in CATEGORY_GROUPS
+                group_key
                 for group_key in categories.keys()
                 if group_key not in CATEGORY_GROUPS
             ]


### PR DESCRIPTION
testJsonFiles_whenFileHasCategories_shouldBeValid when the assertion fails returns a list of booleans as error object  instead of list of wrong keys.

### error when test fails before fix
```shell
FAILED tests/kb_test.py::testJsonFiles_whenFileHasCategories_shouldBeValid - AssertionError: [False]
```

### error after fix
```shell
FAILED tests/kb_test.py::testJsonFiles_whenFileHasCategories_shouldBeValid - AssertionError: ['OWASP_MASVS_v2_']
```