### PR TITLE
feature: Add flutter recommendation

### DIFF
--- a/MOBILE_CLIENT/ANDROID/_HIGH/DANGEROUS_API_WEBVIEW/recommendation.md
+++ b/MOBILE_CLIENT/ANDROID/_HIGH/DANGEROUS_API_WEBVIEW/recommendation.md
@@ -1,15 +1,28 @@
 To Mitigate Dangerous WebView API Usage:
 
 ### Primary Defense – Disable Mixed Content:
+
+**Native Android (Java):**
 ```java
 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
     webView.getSettings().setMixedContentMode(WebSettings.MIXED_CONTENT_NEVER_ALLOW);
 }
+
 ```
-- Prevents HTTPS pages from loading insecure HTTP resources
-- Stops man-in-the-middle attacks via injected scripts
+
+**Flutter (e.g., `flutter_inappwebview`):**
+
+```dart
+InAppWebViewSettings(mixedContentMode: MixedContentMode.MIXED_CONTENT_NEVER_ALLOW)
+
+```
+
+* Prevents HTTPS pages from loading insecure HTTP resources
+* Stops man-in-the-middle attacks via injected scripts
 
 ### Restrict File Access:
+
+**Native Android (Java):**
 
 ```java
 webView.getSettings().setAllowFileAccess(false);
@@ -17,30 +30,69 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
     webView.getSettings().setAllowFileAccessFromFileURLs(false);
     webView.getSettings().setAllowUniversalAccessFromFileURLs(false);
 }
+
 ```
-- Blocks file:// scheme exploitation
-- Prevents local file and database leakage
+
+**Flutter (e.g., `flutter_inappwebview`):**
+
+```dart
+InAppWebViewSettings(
+  allowFileAccess: false,
+  allowFileAccessFromFileURLs: false,
+  allowUniversalAccessFromFileURLs: false,
+)
+
+```
+
+* Blocks file:// scheme exploitation
+* Prevents local file and database leakage
 
 ### Harden JavaScript Interface:
+
+**Native Android (Java):**
 
 ```java
 webView.removeJavascriptInterface("interfaceName"); // Remove if not needed
 // If required, only expose minimal @JavascriptInterface methods
+
 ```
-- Avoids remote code execution via addJavascriptInterface()
-- Use WebMessagePort or allowlist trusted origins if JS bridge is required
+
+**Flutter:**
+Remove unused JS handlers. If required, securely restrict logic within `addJavaScriptHandler` (`flutter_inappwebview`) or `JavascriptChannel` (`webview_flutter`).
+
+* Avoids remote code execution via addJavascriptInterface()
+* Use WebMessagePort or allowlist trusted origins if JS bridge is required
 
 ### Additional Protections:
 
-- Disable WebView debugging in production:
+* Disable WebView debugging in production:
+**Native Android:**
+
 ```java
 WebView.setWebContentsDebuggingEnabled(false);
+
 ```
 
-- Enable Safe Browsing (API 26+):
+**Flutter (e.g., `flutter_inappwebview`):**
+
+```dart
+InAppWebViewSettings(isInspectable: false, debuggingEnabled: false)
+
+```
+
+* Enable Safe Browsing (API 26+):
+**Native Android:**
 
 ```java
 WebView.enableSafeBrowsing(context);
+
+```
+
+**Flutter (e.g., `flutter_inappwebview`):**
+
+```dart
+InAppWebViewSettings(safeBrowsingEnabled: true)
+
 ```
 
 By disabling mixed content, restricting file access, and securing JavaScript bridges, you eliminate the primary attack vectors associated with dangerous WebView APIs while keeping the app’s WebView functionality secure.

--- a/MOBILE_CLIENT/ANDROID/_INFO/APK_ANALYZE_JNI_ELF/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_INFO/APK_ANALYZE_JNI_ELF/meta.json
@@ -3,7 +3,7 @@
   "short_description": "List of JNI methods defined in ELF files and used by the application",
   "references": {
     "JNI Tips": "https://developer.android.com/training/articles/perf-jni.html",
-    "Best practices for using the Java Native Interface": "https://www.ibm.com/developerworks/library/j-jni/"
+    "Best practices for using the Java Native Interface": "https://developer.ibm.com/articles/j-jni/"
   },
   "title": "List of JNI methods",
   "privacy_issue": false,

--- a/MOBILE_CLIENT/ANDROID/_LOW/INTENT_SPOOFING/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_LOW/INTENT_SPOOFING/meta.json
@@ -2,7 +2,7 @@
   "risk_rating": "medium",
   "short_description": "The application is vulnerable to intent spoofing which may lead to inappropriate access like data modification, information disclosure and data injection.",
   "references": {
-    "DRD06. Verify the caller of intents before acting on them": "https://wiki.sei.cmu.edu/confluence/display/android/DRD06.+Verify+the+caller+of+intents+before+acting+on+them",
+    "DRD06. Verify the caller of intents before acting on them": "https://cmu-sei.github.io/secure-coding-standards/android-secure-coding-standard/rules/intent-itt/drd06-verify-the-caller-of-intents-before-acting-on-them",
     "Improper Access Control (CWE-284)": "https://cwe.mitre.org/data/definitions/284.html",
     "Intent Spoof (CAPEC-502)": "https://capec.mitre.org/data/definitions/502.html",
     "Analyzing Inter-Application Communication in Android": "https://people.eecs.berkeley.edu/~daw/papers/intents-mobisys11.pdf"

--- a/MOBILE_CLIENT/ANDROID/_MEDIUM/WEBVIEW_LOADURL_INJECTION/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_MEDIUM/WEBVIEW_LOADURL_INJECTION/meta.json
@@ -2,7 +2,7 @@
   "risk_rating": "medium",
   "short_description": "Insecure use of Webview.loadurl leading to insecure content loading or potential code injection.",
   "references": {
-    "DRD02-J. Do not allow WebView to access sensitive local resource through file scheme": "https://wiki.sei.cmu.edu/confluence/display/android/DRD02-J.+Do+not+allow+WebView+to+access+sensitive+local+resource+through+file+scheme",
+    "DRD02-J. Do not allow WebView to access sensitive local resource through file scheme": "https://cmu-sei.github.io/secure-coding-standards/android-secure-coding-standard/rules/webview-wbv",
     "Webview loadurl (Android documentation)": "https://developer.android.com/reference/android/webkit/WebView#loadUrl(java.lang.String,%2520java.util.Map%253Cjava.lang.String,%2520java.lang.String%253E)",
     "Websettings (Android documentation)": "https://developer.android.com/reference/android/webkit/WebSettings"
   },

--- a/MOBILE_CLIENT/ANDROID/_MEDIUM/WEBVIEW_LOADURL_INJECTION/recommendation.md
+++ b/MOBILE_CLIENT/ANDROID/_MEDIUM/WEBVIEW_LOADURL_INJECTION/recommendation.md
@@ -1,6 +1,6 @@
 All untrusted URLs must have proper input validation to ensure only
 trusted content is accessible. For instance, if the application is
-loading local assets, the list of loaded URL must be whitelisted.
+loading local assets, the list of loaded URLs must be whitelisted.
 
 The `Webview` settings must also be hardened, removing all non required
 settings, like javascript or file access.
@@ -29,3 +29,38 @@ settings, like javascript or file access.
 	}
 	```
 
+=== "Dart (Flutter - flutter_inappwebview)"
+    ```dart
+    import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+    import 'package:flutter/material.dart';
+
+    class SafeWebViewWidget extends StatelessWidget {
+      final String untrustedUrl;
+      static const List<String> WHITELISTED_URLS = [
+        "url1",
+        "url2"
+      ];
+
+      SafeWebViewWidget({required this.untrustedUrl});
+
+      @override
+      Widget build(BuildContext context) {
+        // Validate the incoming URL against the whitelist
+        String safeUrl = "about:blank";
+        if (WHITELISTED_URLS.contains(untrustedUrl)) {
+          safeUrl = untrustedUrl;
+        }
+
+        return InAppWebView(
+          initialUrlRequest: URLRequest(url: WebUri(safeUrl)),
+          initialSettings: InAppWebViewSettings(
+            // Harden settings by disabling features if not strictly required
+            javaScriptEnabled: false, 
+            allowFileAccess: false,
+            allowFileAccessFromFileURLs: false,
+            allowUniversalAccessFromFileURLs: false,
+          ),
+        );
+      }
+    }
+    ```

--- a/MOBILE_CLIENT/COMMON/_MEDIUM/INSECURE_DYNAMICALLY_LINKED_LIBRARY/meta.json
+++ b/MOBILE_CLIENT/COMMON/_MEDIUM/INSECURE_DYNAMICALLY_LINKED_LIBRARY/meta.json
@@ -3,7 +3,7 @@
   "short_description": "Loading Dynamic Libraries without proper input sanitization and verifications.",
   "references": {
     "CWE-426: Untrusted Search Path": "https://cwe.mitre.org/data/definitions/426.html",
-    "WIN00-C. Be specific when dynamically loading libraries": "https://wiki.sei.cmu.edu/confluence/display/c/WIN00-C.+Be+specific+when+dynamically+loading+libraries"
+    "WIN00-C. Be specific when dynamically loading libraries": "https://cmu-sei.github.io/secure-coding-standards/sei-cert-c-coding-standard/recommendations/microsoft-windows-win/win00-c"
   },
   "title": "Insecure Dynamic Library Loading",
   "privacy_issue": false,

--- a/WEB_SERVICE/DNS/_MEDIUM/DNS_TXT_RECORDS_MALICIOUS_CONTENT/meta.json
+++ b/WEB_SERVICE/DNS/_MEDIUM/DNS_TXT_RECORDS_MALICIOUS_CONTENT/meta.json
@@ -4,7 +4,6 @@
   "risk_rating": "medium",
   "references": {
     "Splunk Deep Learning Blog": "https://www.splunk.com/en_us/blog/security/ml-in-security-detect-suspicious-txt-records-using-deep-learning.html",
-    "AhnLab Security Blog": "https://asec.ahnlab.com/en/54916/",
     "ProSec Networks": "https://www.prosec-networks.com/en/blog/dns-tunneling-erkennen/"
   },
   "privacy_issue": false,


### PR DESCRIPTION
**Title:** Add Flutter mitigations for WebView vulnerabilities

**Summary:**
This PR updates the recommendation guidelines for two WebView-related vulnerabilities to include Flutter-specific fixes. Since our scanners catch native Android vulnerabilities inside compiled Flutter apps, providing Dart implementations alongside the native Java fixes gives cross-platform developers directly actionable solutions.

**Changes Included:**

* **Call to dangerous WebView settings API:** Added `flutter_inappwebview` Dart snippets to configure `InAppWebViewSettings` (disabling mixed content, restricting file access, and hardening debugging/safe browsing).
* **Webview loadurl injection:** Added Dart code examples demonstrating how to validate and whitelist untrusted URLs before passing them to a Flutter WebView widget.

**Why:**
Addresses customer feedback where Flutter developers were only receiving native Java mitigation steps that they could not easily apply to third-party Dart packages.