### PR TITLE
feature: add KB entry for missing root/jailbreak detection

### DIFF
--- a/MOBILE_CLIENT/COMMON/_HARDENING/ROOT_DETECTION_MISSING/description.md
+++ b/MOBILE_CLIENT/COMMON/_HARDENING/ROOT_DETECTION_MISSING/description.md
@@ -1,0 +1,10 @@
+The application was installed on a rooted/jailbroken device and continued to run normally, with no detection or restriction in place.
+
+A rooted/jailbroken device removes the platform sandbox: any user — or any malware running with elevated privileges — has unrestricted access to the application's process memory, private storage, and inter-process communication channels. An app that does not detect this condition cannot enforce the OS security boundary it normally relies on, and any sensitive data or business logic shipped inside the app should be considered exposed.
+
+**Common attack scenarios:**
+
+- **Sandbox bypass:** Read the app's private storage and databases directly from a privileged shell, bypassing the per-app isolation the OS would otherwise enforce.
+- **Runtime instrumentation:** Attach a dynamic instrumentation framework to hook sensitive methods, dump keys, or alter business logic at runtime.
+- **Credential and token theft:** Extract material from platform-backed key storage while it is unlocked, and harvest session tokens from process memory.
+- **Combined attack:** Pair elevated device privileges with a re-signed or patched build to disable in-app license checks, anti-cheat, or fraud controls.

--- a/MOBILE_CLIENT/COMMON/_HARDENING/ROOT_DETECTION_MISSING/meta.json
+++ b/MOBILE_CLIENT/COMMON/_HARDENING/ROOT_DETECTION_MISSING/meta.json
@@ -1,0 +1,36 @@
+{
+  "risk_rating": "hardening",
+  "short_description": "The application does not detect or respond to execution on a rooted/jailbroken device.",
+  "title": "Missing Root/Jailbreak Detection",
+  "privacy_issue": false,
+  "security_issue": true,
+  "references": {
+    "OWASP MASWE - Root/Jailbreak Detection Not Implemented (MASWE-0097)": "https://mas.owasp.org/MASWE/MASVS-RESILIENCE/MASWE-0097/",
+    "OWASP MASTG - Testing Root Detection (MASTG-TEST-0045)": "https://mas.owasp.org/MASTG/tests/android/MASVS-RESILIENCE/MASTG-TEST-0045/",
+    "OWASP MASTG - Testing Jailbreak Detection (MASTG-TEST-0088)": "https://mas.owasp.org/MASTG/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0088/",
+    "OWASP MASTG - Implementing Root Detection (MASTG-BEST-0030)": "https://mas.owasp.org/MASTG/best-practices/MASTG-BEST-0030/",
+    "OWASP MASVS - MASVS-RESILIENCE-1": "https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-1/",
+    "Android Developers - Play Integrity API": "https://developer.android.com/google/play/integrity/overview",
+    "Apple Developer - Establishing your app's integrity (DeviceCheck / App Attest)": "https://developer.apple.com/documentation/devicecheck/establishing-your-app-s-integrity"
+  },
+  "categories": {
+    "OWASP_MASVS_RESILIENCE": [
+      "MSTG_RESILIENCE_1"
+    ],
+    "OWASP_MASVS_v2_1": [
+      "MASVS_RESILIENCE_1"
+    ],
+    "PCI_STANDARDS": [
+      "REQ_6_2",
+      "REQ_6_3"
+    ],
+    "SOC2_CONTROLS": [
+      "CC_7_1",
+      "CC_7_2"
+    ],
+    "HIPAA_CONTROLS": [
+      "SECURITY212",
+      "SECURITY213"
+    ]
+  }
+}

--- a/MOBILE_CLIENT/COMMON/_HARDENING/ROOT_DETECTION_MISSING/recommendation.md
+++ b/MOBILE_CLIENT/COMMON/_HARDENING/ROOT_DETECTION_MISSING/recommendation.md
@@ -1,0 +1,88 @@
+Detect rooted/jailbroken devices at runtime and refuse to run — or restrict sensitive functionality — when indicators are found. Combine several signals; any single check is trivial to bypass.
+
+=== "Kotlin"
+	```kotlin
+	import android.content.Context
+	import android.content.pm.PackageManager
+	import android.os.Build
+	import java.io.File
+
+	fun isDeviceRooted(context: Context): Boolean {
+	    // 1. Common su binary locations.
+	    val suPaths = arrayOf(
+	        "/system/bin/su", "/system/xbin/su", "/sbin/su",
+	        "/system/app/Superuser.apk", "/system/etc/init.d/99SuperSUDaemon"
+	    )
+	    if (suPaths.any { File(it).exists() }) return true
+
+	    // 2. Build tags set to test-keys on custom/rooted ROMs.
+	    if (Build.TAGS?.contains("test-keys") == true) return true
+
+	    // 3. Known root-management packages.
+	    val rootPackages = arrayOf(
+	        "com.topjohnwu.magisk",
+	        "eu.chainfire.supersu",
+	        "com.koushikdutta.superuser"
+	    )
+	    val pm = context.packageManager
+	    for (pkg in rootPackages) {
+	        try {
+	            pm.getPackageInfo(pkg, 0)
+	            return true
+	        } catch (_: PackageManager.NameNotFoundException) {
+	        }
+	    }
+	    return false
+	}
+	```
+
+=== "Swift"
+	```swift
+	import Foundation
+	import UIKit
+
+	func isDeviceJailbroken() -> Bool {
+	    #if targetEnvironment(simulator)
+	    return false
+	    #else
+	    // 1. Common jailbreak file paths.
+	    let suspiciousPaths = [
+	        "/Applications/Cydia.app",
+	        "/Applications/Sileo.app",
+	        "/Library/MobileSubstrate/MobileSubstrate.dylib",
+	        "/usr/sbin/sshd",
+	        "/etc/apt",
+	        "/private/var/lib/apt/",
+	        "/var/jb"
+	    ]
+	    for path in suspiciousPaths where FileManager.default.fileExists(atPath: path) {
+	        return true
+	    }
+
+	    // 2. Sandbox escape: writing outside the app container only succeeds on jailbroken devices.
+	    let testPath = "/private/jb_probe.txt"
+	    do {
+	        try "x".write(toFile: testPath, atomically: true, encoding: .utf8)
+	        try? FileManager.default.removeItem(atPath: testPath)
+	        return true
+	    } catch {
+	        // Expected on a non-jailbroken device.
+	    }
+
+	    // 3. Suspicious URL schemes registered by jailbreak managers.
+	    if let url = URL(string: "cydia://package/com.example.package"),
+	       UIApplication.shared.canOpenURL(url) {
+	        return true
+	    }
+
+	    return false
+	    #endif
+	}
+	```
+
+Additional hardening recommendations:
+
+- Use the platform attestation service as the authoritative signal, validated server-side: **Play Integrity API** (`MEETS_DEVICE_INTEGRITY` / `MEETS_STRONG_INTEGRITY`) for Android, **DeviceCheck / App Attest** for iOS. Local checks are defense in depth, not the primary control.
+- Perform the local checks in a native function (JNI on Android, plain C on iOS) and in multiple locations to resist patching and runtime hooking.
+- Terminate or wipe sensitive state on detection — do not degrade gracefully, and do not surface a single, hookable "is rooted/jailbroken" boolean that an attacker can pin to `false`.
+- Never gate critical security decisions on the client-side check alone; treat it as advisory on the client and authoritative only after a server-side attestation check.

--- a/MOBILE_CLIENT/COMMON/_SECURE/ROOT_DETECTION_PRESENT/description.md
+++ b/MOBILE_CLIENT/COMMON/_SECURE/ROOT_DETECTION_PRESENT/description.md
@@ -1,0 +1,3 @@
+The application detected that it was running on a rooted/jailbroken device and responded by terminating, blocking sensitive functionality, or displaying a security warning.
+
+This indicates the app performs runtime checks against known indicators of an elevated-privilege environment, reducing the impact of runtime instrumentation, sandbox bypass, and tampering attacks that depend on such an environment.

--- a/MOBILE_CLIENT/COMMON/_SECURE/ROOT_DETECTION_PRESENT/meta.json
+++ b/MOBILE_CLIENT/COMMON/_SECURE/ROOT_DETECTION_PRESENT/meta.json
@@ -1,0 +1,38 @@
+{
+  "risk_rating": "secure",
+  "short_description": "The application detects and responds to execution on a rooted/jailbroken device.",
+  "title": "Root/Jailbreak Detection Implemented",
+  "privacy_issue": false,
+  "security_issue": true,
+  "targeted_by_malware": false,
+  "targeted_by_ransomware": false,
+  "targeted_by_nation_state": false,
+  "has_public_exploit": false,
+  "references": {
+    "OWASP MASWE - Root/Jailbreak Detection Not Implemented (MASWE-0097)": "https://mas.owasp.org/MASWE/MASVS-RESILIENCE/MASWE-0097/",
+    "OWASP MASTG - Testing Root Detection (MASTG-TEST-0045)": "https://mas.owasp.org/MASTG/tests/android/MASVS-RESILIENCE/MASTG-TEST-0045/",
+    "OWASP MASTG - Testing Jailbreak Detection (MASTG-TEST-0088)": "https://mas.owasp.org/MASTG/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0088/",
+    "OWASP MASTG - Implementing Root Detection (MASTG-BEST-0030)": "https://mas.owasp.org/MASTG/best-practices/MASTG-BEST-0030/",
+    "OWASP MASVS - MASVS-RESILIENCE-1": "https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-1/"
+  },
+  "categories": {
+    "OWASP_MASVS_RESILIENCE": [
+      "MSTG_RESILIENCE_1"
+    ],
+    "OWASP_MASVS_v2_1": [
+      "MASVS_RESILIENCE_1"
+    ],
+    "PCI_STANDARDS": [
+      "REQ_6_2",
+      "REQ_6_3"
+    ],
+    "SOC2_CONTROLS": [
+      "CC_7_1",
+      "CC_7_2"
+    ],
+    "HIPAA_CONTROLS": [
+      "SECURITY212",
+      "SECURITY213"
+    ]
+  }
+}


### PR DESCRIPTION
- New `_HARDENING` KB entry at `MOBILE_CLIENT/COMMON/_HARDENING/ROOT_DETECTION_MISSING/` describing apps that run unrestricted on rooted/jailbroken devices.
- New `_SECURE` counterpart at `MOBILE_CLIENT/COMMON/_SECURE/ROOT_DETECTION_PRESENT/` 