### PR TITLE
feature: Add frida hooking anti tampering entry

### DIFF
--- a/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/description.md
+++ b/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/description.md
@@ -1,0 +1,10 @@
+The application continued to run normally with Frida attached and its hook script injected into the running process.
+
+When Frida is active, an attacker can intercept and modify any Java or native method at runtime — bypassing signature checks, license validation, root detection, certificate pinning, and other security controls without modifying the APK.
+
+**Common attack scenarios:**
+
+- **Anti-tampering bypass:** Hook signature verification or root detection methods to return expected values while the attacker-controlled environment remains in place.
+- **Secrets extraction:** Intercept cryptographic operations to extract keys, tokens, or session credentials from memory.
+- **Logic manipulation:** Modify return values of business logic methods (e.g., payment validation, access control) in real time.
+- **Combined attack:** Use Frida alongside a repackaged APK to bypass both static and runtime protections simultaneously.

--- a/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/meta.json
@@ -1,0 +1,35 @@
+{
+  "risk_rating": "hardening",
+  "short_description": "The application does not detect or respond to the presence of the Frida dynamic instrumentation framework.",
+  "title": "Missing Frida Instrumentation Detection",
+  "privacy_issue": false,
+  "security_issue": true,
+  "references": {
+    "OWASP MASTG - Testing Reverse Engineering Tools Detection (MASTG-TEST-0048)": "https://mas.owasp.org/MASTG/tests/android/MASVS-RESILIENCE/MASTG-TEST-0048/",
+    "OWASP MASVS - MASVS-RESILIENCE-4": "https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-4/",
+    "Frida - Dynamic Instrumentation Framework": "https://frida.re/"
+  },
+  "categories": {
+    "OWASP_MASVS_RESILIENCE": [
+      "MSTG_RESILIENCE_4"
+    ],
+    "OWASP_MASVS_v2_1": [
+      "MASVS_RESILIENCE_4"
+    ],
+    "PCI_STANDARDS": [
+      "REQ_6_2",
+      "REQ_6_3"
+    ],
+    "SOC2_CONTROLS": [
+      "CC_7_1",
+      "CC_7_2"
+    ],
+    "HIPAA_CONTROLS": [
+      "SECURITY212",
+      "SECURITY213"
+    ],
+    "OWASP_MOBILE_TOP_10": [
+      "M7_2024"
+    ]
+  }
+}

--- a/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/meta.json
@@ -7,7 +7,9 @@
   "references": {
     "OWASP MASTG - Testing Reverse Engineering Tools Detection (MASTG-TEST-0048)": "https://mas.owasp.org/MASTG/tests/android/MASVS-RESILIENCE/MASTG-TEST-0048/",
     "OWASP MASVS - MASVS-RESILIENCE-4": "https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-4/",
-    "Frida - Dynamic Instrumentation Framework": "https://frida.re/"
+    "Frida - Dynamic Instrumentation Framework": "https://frida.re/",
+    "DetectFrida - Memory-to-disk comparison reference implementation": "https://github.com/darvincisec/DetectFrida",
+    "Frida Detection & Prevention (Approov)": "https://approov.io/knowledge/frida-detection-prevention"
   },
   "categories": {
     "OWASP_MASVS_RESILIENCE": [

--- a/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/recommendation.md
+++ b/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/recommendation.md
@@ -1,0 +1,29 @@
+Detect Frida's presence at runtime and terminate or degrade when it is found.
+
+**Detection approaches:**
+
+1. **Process map scanning:** Read `/proc/self/maps` and scan for frida-related strings (`frida`, `gum-js-loop`, `frida-agent`).
+
+```java
+try (BufferedReader reader = new BufferedReader(new FileReader("/proc/self/maps"))) {
+    String line;
+    while ((line = reader.readLine()) != null) {
+        if (line.contains("frida") || line.contains("gum-js-loop")) {
+            throw new SecurityException("Instrumentation framework detected.");
+        }
+    }
+}
+```
+
+2. **Port scanning:** Frida's default server port is 27042. Detecting an open local port is a lightweight signal.
+
+3. **Named pipe / D-bus detection:** Check for Frida's IPC artifacts in `/tmp` or via D-bus enumeration.
+
+4. **Native integrity check:** Implement detection in a JNI function to resist easy hook patching from Java.
+
+**Additional hardening:**
+
+- Perform checks in multiple locations and at different lifecycle points (startup, background thread, on sensitive operations).
+- Obfuscate check logic and check strings to resist static analysis.
+- Combine with root detection — Frida typically requires a rooted or otherwise instrumented device.
+- Terminate or wipe sensitive state immediately on detection rather than degrading gracefully.

--- a/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/recommendation.md
+++ b/MOBILE_CLIENT/ANDROID/_HARDENING/DYNAMIC_FRIDA_PROTECTION_MISSING/recommendation.md
@@ -1,29 +1,142 @@
-Detect Frida's presence at runtime and terminate or degrade when it is found.
+Detect Frida's presence at runtime and terminate or degrade when it is found. Use multiple independent detection methods — signature-based checks alone can be bypassed with custom Frida builds.
 
 **Detection approaches:**
 
-1. **Process map scanning:** Read `/proc/self/maps` and scan for frida-related strings (`frida`, `gum-js-loop`, `frida-agent`).
+1. **Process map scanning:** Scan `/proc/self/maps` for strings associated with Frida's injected libraries and agent threads.
 
-```java
-try (BufferedReader reader = new BufferedReader(new FileReader("/proc/self/maps"))) {
-    String line;
-    while ((line = reader.readLine()) != null) {
-        if (line.contains("frida") || line.contains("gum-js-loop")) {
-            throw new SecurityException("Instrumentation framework detected.");
+=== "Kotlin"
+    ```kotlin
+    private val FRIDA_SIGNATURES = listOf(
+        "frida-agent", "frida-gadget", "frida-server", "gum-js-loop", "frida-helper"
+    )
+
+    fun isFridaInMaps(): Boolean {
+        return try {
+            File("/proc/self/maps").readLines().any { line ->
+                FRIDA_SIGNATURES.any { sig -> line.contains(sig) }
+            }
+        } catch (_: IOException) {
+            false
         }
     }
-}
-```
+    ```
 
-2. **Port scanning:** Frida's default server port is 27042. Detecting an open local port is a lightweight signal.
+=== "Java"
+    ```java
+    private static final List<String> FRIDA_SIGNATURES = Arrays.asList(
+        "frida-agent", "frida-gadget", "frida-server", "gum-js-loop", "frida-helper"
+    );
 
-3. **Named pipe / D-bus detection:** Check for Frida's IPC artifacts in `/tmp` or via D-bus enumeration.
+    public static boolean isFridaInMaps() {
+        try (BufferedReader reader = new BufferedReader(new FileReader("/proc/self/maps"))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                for (String sig : FRIDA_SIGNATURES) {
+                    if (line.contains(sig)) return true;
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return false;
+    }
+    ```
 
-4. **Native integrity check:** Implement detection in a JNI function to resist easy hook patching from Java.
+2. **WebSocket handshake detection:** Frida's server responds to a WebSocket upgrade request with a fixed, predictable `Sec-WebSocket-Accept` key regardless of which port it is running on. Scanning all ports and matching this key detects Frida even when the default port 27042 has been changed.
+
+=== "Native (C/JNI)"
+    ```c
+    static const char *FRIDA_WS_KEY = "tyZql/Y8dNFFyopTrHadWzvbvRs=";
+
+    bool detect_frida_listener() {
+        struct sockaddr_in addr = {0};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+        for (int port = 1; port < 65535; port++) {
+            addr.sin_port = htons(port);
+            int fd = socket(AF_INET, SOCK_STREAM, 0);
+            if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
+                const char *req =
+                    "GET /ws HTTP/1.1\r\nUpgrade: websocket\r\n"
+                    "Connection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n";
+                write(fd, req, strlen(req));
+                char res[1024] = {0};
+                if (read(fd, res, sizeof(res) - 1) > 0 && strstr(res, FRIDA_WS_KEY)) {
+                    close(fd);
+                    return true;
+                }
+            }
+            close(fd);
+        }
+        return false;
+    }
+    ```
+
+3. **Named pipe detection:** Frida creates named pipes under `/proc/self/fd` for IPC between the agent and the host. Scanning file descriptors for Frida-related pipe names catches injected gadgets.
+
+=== "Kotlin"
+    ```kotlin
+    fun isFridaNamedPipePresent(): Boolean {
+        return File("/proc/self/fd").listFiles()?.any { fd ->
+            try {
+                fd.canonicalPath.contains("frida")
+            } catch (_: IOException) {
+                false
+            }
+        } ?: false
+    }
+    ```
+
+=== "Java"
+    ```java
+    public static boolean isFridaNamedPipePresent() {
+        File[] fds = new File("/proc/self/fd").listFiles();
+        if (fds == null) return false;
+        for (File fd : fds) {
+            try {
+                if (fd.getCanonicalPath().contains("frida")) return true;
+            } catch (IOException ignored) {
+            }
+        }
+        return false;
+    }
+    ```
+
+4. **Thread name detection:** Frida spawns threads with recognisable names. Scanning `/proc/self/task/<tid>/comm` for known Frida thread names detects an attached agent.
+
+=== "Kotlin"
+    ```kotlin
+    private val FRIDA_THREAD_NAMES = listOf("gum-js-loop", "frida-server", "gmain", "pool-frida")
+
+    fun isFridaThreadPresent(): Boolean {
+        return File("/proc/self/task").listFiles()?.any { tid ->
+            val comm = File(tid, "comm").readText().trim()
+            FRIDA_THREAD_NAMES.any { name -> comm.contains(name) }
+        } ?: false
+    }
+    ```
+
+5. **File artifact detection:** Check for Frida server binaries commonly dropped to device storage.
+
+=== "Kotlin"
+    ```kotlin
+    private val FRIDA_ARTIFACTS = listOf(
+        "/data/local/tmp/frida-server",
+        "/data/local/tmp/re.frida.server",
+        "/sdcard/frida-server"
+    )
+
+    fun isFridaArtifactPresent(): Boolean = FRIDA_ARTIFACTS.any { File(it).exists() }
+    ```
+
+6. **Memory-to-disk comparison (frida-agnostic):** Compare the `.text` section of loaded libraries in memory against their on-disk counterparts. Any hooking framework — not just Frida — that modifies instructions at runtime will cause a mismatch. This approach survives custom Frida builds that remove all string signatures.
+
+    Implement via JNI, comparing `mmap`-loaded disk bytes against the live in-process mapping for `libc.so` and your own native library. See [darvincisec/DetectFrida](https://github.com/darvincisec/DetectFrida) for a reference implementation that handles the PLT/TEXT boundary correctly on Android 10+.
 
 **Additional hardening:**
 
-- Perform checks in multiple locations and at different lifecycle points (startup, background thread, on sensitive operations).
-- Obfuscate check logic and check strings to resist static analysis.
-- Combine with root detection — Frida typically requires a rooted or otherwise instrumented device.
-- Terminate or wipe sensitive state immediately on detection rather than degrading gracefully.
+- Run checks from native code (JNI) — Java-layer checks are trivially patched by hooking the return value.
+- Obfuscate detection strings; a string like `"frida-agent"` in plaintext can be patched in the binary with a hex editor.
+- Schedule checks on a background thread and re-run them periodically — Frida can be attached after app startup.
+- Combine with root detection; Frida server typically requires root or an unlocked bootloader.
+- On detection, terminate immediately and wipe any sensitive in-memory state rather than degrading gracefully — graceful degradation is predictable and easier to bypass.

--- a/MOBILE_CLIENT/ANDROID/_SECURE/DYNAMIC_FRIDA_PROTECTION_PRESENT/description.md
+++ b/MOBILE_CLIENT/ANDROID/_SECURE/DYNAMIC_FRIDA_PROTECTION_PRESENT/description.md
@@ -1,0 +1,3 @@
+The application detected that the Frida dynamic instrumentation framework was attached to its process and responded by terminating or displaying a security warning.
+
+This indicates the app performs runtime anti-instrumentation checks, preventing an attacker from using Frida to intercept method calls, extract secrets, or manipulate execution flow at runtime.

--- a/MOBILE_CLIENT/ANDROID/_SECURE/DYNAMIC_FRIDA_PROTECTION_PRESENT/meta.json
+++ b/MOBILE_CLIENT/ANDROID/_SECURE/DYNAMIC_FRIDA_PROTECTION_PRESENT/meta.json
@@ -1,0 +1,38 @@
+{
+  "risk_rating": "secure",
+  "short_description": "The application correctly detects and responds to the presence of the Frida dynamic instrumentation framework.",
+  "title": "Frida Instrumentation Detection Implemented",
+  "privacy_issue": false,
+  "security_issue": true,
+  "targeted_by_malware": false,
+  "targeted_by_ransomware": false,
+  "targeted_by_nation_state": false,
+  "has_public_exploit": false,
+  "references": {
+    "OWASP MASTG - Testing Reverse Engineering Tools Detection (MASTG-TEST-0048)": "https://mas.owasp.org/MASTG/tests/android/MASVS-RESILIENCE/MASTG-TEST-0048/",
+    "OWASP MASVS - MASVS-RESILIENCE-4": "https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-4/"
+  },
+  "categories": {
+    "OWASP_MASVS_RESILIENCE": [
+      "MSTG_RESILIENCE_4"
+    ],
+    "OWASP_MASVS_v2_1": [
+      "MASVS_RESILIENCE_4"
+    ],
+    "PCI_STANDARDS": [
+      "REQ_6_2",
+      "REQ_6_3"
+    ],
+    "SOC2_CONTROLS": [
+      "CC_7_1",
+      "CC_7_2"
+    ],
+    "HIPAA_CONTROLS": [
+      "SECURITY212",
+      "SECURITY213"
+    ],
+    "OWASP_MOBILE_TOP_10": [
+      "M7_2024"
+    ]
+  }
+}

--- a/MOBILE_CLIENT/ANDROID/_SECURE/DYNAMIC_FRIDA_PROTECTION_PRESENT/recommendation.md
+++ b/MOBILE_CLIENT/ANDROID/_SECURE/DYNAMIC_FRIDA_PROTECTION_PRESENT/recommendation.md
@@ -1,0 +1,1 @@
+The implementation is secure, no recommendation applies.

--- a/tests/kb_test.py
+++ b/tests/kb_test.py
@@ -1299,6 +1299,7 @@ def testJsonFiles_whenFileHasCategories_shouldBeValid() -> None:
             ]
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def testMetaFiles_always_referencesShouldHaveValidLinks() -> None:
     """Ensure all URLs in the `references` field of meta.json files are valid across all groups"""
     base_path = pathlib.Path(__file__).parent.parent

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-cov
 pytest-mock
+pytest-rerunfailures
 pyfakefs
 types-requests


### PR DESCRIPTION
**Add frida hooking anti tampering entry**.

Also adds flaky to url confirmation test, it often fails and requires a second rerun of the whole job:
Wikipedia urls here are all valid:
<img width="1417" height="413" alt="image" src="https://github.com/user-attachments/assets/23dbe42a-bf29-402a-8981-bac0d1ecaa4e" />
