### PR TITLE
fix: remove codecov config

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,10 +29,4 @@ jobs:
       - name: Running tests with pytest.
         run: |
           set -o pipefail
-          pytest --cov=./ --cov-report=xml:coverage.xml --cov-report=term-missing
-      - name: Upload coverage to Codecov.
-        uses: codecov/codecov-action@v4
-        with:
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.xml
+          pytest


### PR DESCRIPTION
Removes the Codecov upload step and coverage flags from the CI workflow.