### PR TITLE
feature: Add KB entry for PII leaked in network traffic

### DIFF
--- a/MOBILE_CLIENT/COMMON/_MEDIUM/LEAKING_PERSONAL_INFORMATION_REQUEST/description.md
+++ b/MOBILE_CLIENT/COMMON/_MEDIUM/LEAKING_PERSONAL_INFORMATION_REQUEST/description.md
@@ -1,0 +1,65 @@
+Personally Identifiable Information (PII) is, according to NIST Special Publication 800-122, a collective term for any information that can be used to distinguish or trace an individual's identity, such as name, social security number, date and place of birth, mother's maiden name, or biometric records; and any other information that is linked or linkable to an individual, such as medical, educational, financial, and employment information.
+
+In the context of mobile security, PII leakage in network traffic occurs when plain text PII is transmitted in an HTTP(S) request or response body, headers, or URL/query parameters, making it accessible to anyone able to observe the traffic: intermediate proxies, logging infrastructure, analytics/crash-reporting SDKs, or an attacker positioned on the network.
+
+=== "Kotlin"
+  ```kotlin
+  import okhttp3.OkHttpClient
+  import okhttp3.Request
+  import okhttp3.RequestBody
+  import okhttp3.MediaType.Companion.toMediaType
+
+  val client = OkHttpClient()
+
+  fun submitProfile(email: String, phoneNumber: String, ssn: String) {
+      // PII sent in plain text as URL query parameters and JSON body.
+      val json = """{"email":"$email","phone":"$phoneNumber","ssn":"$ssn"}"""
+      val body = RequestBody.create("application/json".toMediaType(), json)
+      val request = Request.Builder()
+          .url("https://api.example.com/profile?email=$email&ssn=$ssn")
+          .post(body)
+          .build()
+
+      client.newCall(request).execute()
+  }
+  ```
+
+=== "Swift"
+  ```swift
+  import Foundation
+
+  func submitProfile(email: String, phoneNumber: String, ssn: String) {
+      // PII sent in plain text as URL query parameters and JSON body.
+      var components = URLComponents(string: "https://api.example.com/profile")!
+      components.queryItems = [
+          URLQueryItem(name: "email", value: email),
+          URLQueryItem(name: "ssn", value: ssn)
+      ]
+
+      var request = URLRequest(url: components.url!)
+      request.httpMethod = "POST"
+      request.httpBody = try? JSONSerialization.data(withJSONObject: [
+          "email": email,
+          "phone": phoneNumber,
+          "ssn": ssn
+      ])
+
+      URLSession.shared.dataTask(with: request).resume()
+  }
+  ```
+
+=== "Flutter"
+  ```dart
+  import 'package:http/http.dart' as http;
+  import 'dart:convert';
+
+  Future<void> submitProfile(String email, String phoneNumber, String ssn) async {
+    // PII sent in plain text as URL query parameters and JSON body.
+    final uri = Uri.parse('https://api.example.com/profile?email=$email&ssn=$ssn');
+
+    await http.post(
+      uri,
+      body: jsonEncode({'email': email, 'phone': phoneNumber, 'ssn': ssn}),
+    );
+  }
+  ```

--- a/MOBILE_CLIENT/COMMON/_MEDIUM/LEAKING_PERSONAL_INFORMATION_REQUEST/meta.json
+++ b/MOBILE_CLIENT/COMMON/_MEDIUM/LEAKING_PERSONAL_INFORMATION_REQUEST/meta.json
@@ -1,0 +1,53 @@
+{
+  "risk_rating": "medium",
+  "short_description": "Personally Identifiable Information were detected leaked in network traffic.",
+  "references": {
+    "CWE-200: Information Exposure": "https://cwe.mitre.org/data/definitions/200.html",
+    "CWE-359: Exposure of Private Information (\"Privacy Violation\")": "https://cwe.mitre.org/data/definitions/359.html",
+    "CWE-598: Information Exposure Through Query Strings in GET Request": "https://cwe.mitre.org/data/definitions/598.html"
+  },
+  "title": "Personally Identifiable Information (PII) Leakage in Network Traffic",
+  "privacy_issue": true,
+  "security_issue": false,
+  "categories": {
+    "OWASP_MASVS_L1": [
+      "MSTG_ARCH_12",
+      "MSTG_NETWORK_1"
+    ],
+    "OWASP_MASVS_L2": [
+      "MSTG_ARCH_12",
+      "MSTG_NETWORK_1"
+    ],
+    "GDPR": [
+      "ART_32",
+      "ART_25"
+    ],
+    "PCI_STANDARDS": [
+      "REQ_3_2",
+      "REQ_3_3",
+      "REQ_3_5",
+      "REQ_3_6",
+      "REQ_3_7",
+      "REQ_4_2",
+      "REQ_6_2"
+    ],
+    "OWASP_MASVS_v2_1": [
+      "MASVS_STORAGE_1",
+      "MASVS_STORAGE_2",
+      "MASVS_NETWORK_1"
+    ],
+    "SOC2_CONTROLS": [
+      "CC_2_1",
+      "CC_4_1",
+      "CC_7_1",
+      "CC_7_2",
+      "CC_7_4",
+      "CC_7_5"
+    ],
+    "HIPAA_CONTROLS": [
+      "SECURITY251",
+      "SECURITY212",
+      "SECURITY213"
+    ]
+  }
+}

--- a/MOBILE_CLIENT/COMMON/_MEDIUM/LEAKING_PERSONAL_INFORMATION_REQUEST/recommendation.md
+++ b/MOBILE_CLIENT/COMMON/_MEDIUM/LEAKING_PERSONAL_INFORMATION_REQUEST/recommendation.md
@@ -1,0 +1,63 @@
+* Avoid transmitting PII/PHI in URL query parameters; use the request body instead, since URLs are commonly logged by proxies, load balancers, and browser history.
+* Always transmit PII/PHI over an encrypted channel (TLS), never in plain text.
+* Minimize the amount of PII sent to the backend to what is strictly necessary for the request.
+* Mask or redact PII before sending it to third-party analytics, crash-reporting, or logging SDKs.
+* Do not echo PII back in error messages or debug responses.
+* Some jurisdictions may require you to provide a privacy policy for transmitting personal information, and to obtain explicit user consent before sending it off-device.
+* If a backend integration requires PII, ensure it is only sent to first-party, trusted endpoints, and validate third-party SDKs are not silently forwarding it elsewhere.
+
+=== "Kotlin"
+  ```kotlin
+  import okhttp3.OkHttpClient
+  import okhttp3.Request
+  import okhttp3.RequestBody
+  import okhttp3.MediaType.Companion.toMediaType
+
+  val client = OkHttpClient()
+
+  fun submitProfile(email: String, phoneNumber: String, ssn: String) {
+      // PII sent only in the encrypted request body, not in the URL.
+      val json = """{"email":"$email","phone":"$phoneNumber","ssn":"$ssn"}"""
+      val body = RequestBody.create("application/json".toMediaType(), json)
+      val request = Request.Builder()
+          .url("https://api.example.com/profile")
+          .post(body)
+          .build()
+
+      client.newCall(request).execute()
+  }
+  ```
+
+=== "Swift"
+  ```swift
+  import Foundation
+
+  func submitProfile(email: String, phoneNumber: String, ssn: String) {
+      // PII sent only in the encrypted request body, not in the URL.
+      var request = URLRequest(url: URL(string: "https://api.example.com/profile")!)
+      request.httpMethod = "POST"
+      request.httpBody = try? JSONSerialization.data(withJSONObject: [
+          "email": email,
+          "phone": phoneNumber,
+          "ssn": ssn
+      ])
+
+      URLSession.shared.dataTask(with: request).resume()
+  }
+  ```
+
+=== "Flutter"
+  ```dart
+  import 'package:http/http.dart' as http;
+  import 'dart:convert';
+
+  Future<void> submitProfile(String email, String phoneNumber, String ssn) async {
+    // PII sent only in the encrypted request body, not in the URL.
+    final uri = Uri.parse('https://api.example.com/profile');
+
+    await http.post(
+      uri,
+      body: jsonEncode({'email': email, 'phone': phoneNumber, 'ssn': ssn}),
+    );
+  }
+  ```


### PR DESCRIPTION
## Summary
- Existing `LEAKING_PERSONAL_INFORMATION` entry only covers PII found in local files/logs.
- Adds a sibling entry, `LEAKING_PERSONAL_INFORMATION_REQUEST`, scoped to PII detected in HTTP request/response traffic — same pattern as `LEAKING_CREDENTIALS_LOGS` / `LEAKING_CREDENTIALS_REQUEST`.
- To be consumed by `agent_sensitive_info_detector` once it's extended to scan network traffic.

## Test plan
- [x] `pytest tests/kb_test.py` structural checks pass (json validity, unique folder/title names, valid category codes)