### PR TITLE
fix: resolve ruff linter issues in kb_test and kb_generator

### DIFF
--- a/tests/kb_test.py
+++ b/tests/kb_test.py
@@ -4,8 +4,8 @@ import glob
 import json
 import pathlib
 
-import requests
 import pytest
+import requests
 
 CATEGORY_GROUPS = [
     "OWASP_MASVS_L1",
@@ -1133,7 +1133,7 @@ def testJsonFiles_allFilesAreValid_testPasses() -> None:
             try:
                 json_data = json.load(file)
             except ValueError as e:
-                pytest.fail(f"Failed to load JSON file '{json_file}': {str(e)}")
+                pytest.fail(f"Failed to load JSON file '{json_file}': {e!s}")
 
             # Check if the JSON data is a dictionary
             assert isinstance(json_data, dict), "JSON data must be a dictionary."
@@ -1231,7 +1231,7 @@ def testJsonFiles_allFilesHaveCorrectCategories_testPasses(
             try:
                 json_data = json.load(file)
             except ValueError as e:
-                pytest.fail(f"Failed to load JSON file '{json_file}': {str(e)}")
+                pytest.fail(f"Failed to load JSON file '{json_file}': {e!s}")
 
             categories = json_data.get("categories", {})
             standard_categories = categories.get(category, [])
@@ -1250,16 +1250,16 @@ def testJsonFiles_whenFileHasCategories_shouldBeValid() -> None:
             try:
                 json_data = json.load(file)
             except ValueError as e:
-                pytest.fail(f"Failed to load JSON file '{json_file}': {str(e)}")
+                pytest.fail(f"Failed to load JSON file '{json_file}': {e!s}")
 
             categories = json_data.get("categories", {})
 
             assert (
-                all(group_key in CATEGORY_GROUPS for group_key in categories.keys())
+                all(group_key in CATEGORY_GROUPS for group_key in categories)
                 is True
             ), [
                 group_key in CATEGORY_GROUPS
-                for group_key in categories.keys()
+                for group_key in categories
                 if group_key not in CATEGORY_GROUPS
             ]
 

--- a/tests/tools/kb_generator_test.py
+++ b/tests/tools/kb_generator_test.py
@@ -2,8 +2,8 @@
 
 import os.path
 
-from pytest_mock import plugin
 from pyfakefs import fake_filesystem
+from pytest_mock import plugin
 
 from tests import utils
 from tools import kb_generator

--- a/tools/kb_generator.py
+++ b/tools/kb_generator.py
@@ -19,6 +19,7 @@ DEMO_LANGS = ["Flutter", "Swift", "Kotlin"]
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
+logger = logging.getLogger(__name__)
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 MODEL_NAME = "gpt-3.5-turbo"
@@ -100,7 +101,6 @@ META_TEMPLATE = """
 PATTERN = "```(.*)```"
 
 
-@dataclasses.dataclass
 class RiskRating(enum.Enum):
     """RiskRating dataclass"""
 
@@ -111,7 +111,6 @@ class RiskRating(enum.Enum):
     HIGH = "HIGH"
 
 
-@dataclasses.dataclass
 class Platform(enum.Enum):
     """Platform dataclass"""
 
@@ -163,7 +162,7 @@ def dump_kb(kbentry: KBEntry) -> None:
         f"_{kbentry.vulnerability.risk_rating.value}",
     )
 
-    logging.info("KB generated successfully, path is %s", path_prefix)
+    logger.info("KB generated successfully, path is %s", path_prefix)
 
     path_prefix.mkdir(exist_ok=True, parents=True)
 


### PR DESCRIPTION
Fixes ruff linter errors in `kb_test.py` and `kb_generator.py`:
- Removed unnecessary `.keys()` calls in dict key membership checks (`SIM118`)
- Removed `@dataclass` decorator from Enum classes `RiskRating` and `Platform` (`RUF049`)
- Replaced root logger `logging.info()` call with module logger (`LOG015`)